### PR TITLE
Report WebSocket failures to OnConnectionUpdated handler

### DIFF
--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -313,5 +313,7 @@ public sealed class ATWebSocketProtocol : IDisposable
                 this.logger?.LogError(e, "WSS: ATError receiving message.");
             }
         }
+
+        this.OnConnectionUpdated?.Invoke(this, new SubscriptionConnectionStatusEventArgs(webSocket.State));
     }
 }


### PR DESCRIPTION
In the existing code, WebSocket connection interruptions are silent. The `OnConnectionUpdated` event handler is never called, it just stops working. Ideally we would handle this internally (as suggested by #5), but this at least lets the caller address the issue.