### PR TITLE
Added videoSupport to recordviewEmbed

### DIFF
--- a/src/FishyFlip/Models/RecordWithMediaEmbed.cs
+++ b/src/FishyFlip/Models/RecordWithMediaEmbed.cs
@@ -13,12 +13,12 @@ public class RecordWithMediaEmbed : Embed
     /// Initializes a new instance of the <see cref="RecordWithMediaEmbed"/> class.
     /// </summary>
     /// <param name="record">The record to be embedded. Can be null.</param>
-    /// <param name="images">The images to be embedded. Can be null.</param>
+    /// <param name="embed">The media to be embedded. Can be null.</param>
     [JsonConstructor]
-    public RecordWithMediaEmbed(RecordEmbed? record, ImagesEmbed? images)
+    public RecordWithMediaEmbed(RecordEmbed? record, Embed? embed)
     {
         this.Record = record;
-        this.Images = images;
+        this.Embed = embed;
         this.Type = Constants.EmbedTypes.RecordWithMedia;
     }
 
@@ -35,7 +35,7 @@ public class RecordWithMediaEmbed : Embed
         switch (type)
         {
             case Constants.EmbedTypes.Images:
-                this.Images = new ImagesEmbed(media["images"]);
+                this.Embed = new ImagesEmbed(media["images"]);
                 break;
         }
     }
@@ -48,5 +48,5 @@ public class RecordWithMediaEmbed : Embed
     /// <summary>
     /// Gets the images to be embedded.
     /// </summary>
-    public ImagesEmbed? Images { get; }
+    public Embed? Embed { get; }
 }

--- a/src/FishyFlip/Models/RecordWithMediaViewEmbed.cs
+++ b/src/FishyFlip/Models/RecordWithMediaViewEmbed.cs
@@ -19,12 +19,12 @@ public class RecordWithMediaViewEmbed : Embed
     /// Initializes a new instance of the <see cref="RecordWithMediaViewEmbed"/> class.
     /// </summary>
     /// <param name="record">The record view embed.</param>
-    /// <param name="images">The image view embed.</param>
+    /// <param name="embed">The media embed.</param>
     [JsonConstructor]
-    public RecordWithMediaViewEmbed(RecordViewEmbed? record, ImageViewEmbed? images)
+    public RecordWithMediaViewEmbed(RecordViewEmbed? record, Embed? embed)
     {
         this.Record = record;
-        this.Images = images;
+        this.Embed = embed;
         this.Type = Constants.EmbedTypes.RecordWithMedia;
     }
 
@@ -36,5 +36,5 @@ public class RecordWithMediaViewEmbed : Embed
     /// <summary>
     /// Gets the image view embed.
     /// </summary>
-    public ImageViewEmbed? Images { get; }
+    public Embed? Embed { get; }
 }

--- a/src/FishyFlip/Tools/Json/EmbedConverter.cs
+++ b/src/FishyFlip/Tools/Json/EmbedConverter.cs
@@ -94,7 +94,7 @@ public class EmbedConverter : JsonConverter<Embed>
                         break;
                     case Constants.EmbedTypes.RecordWithMediaView:
                         RecordViewEmbed? record1 = null;
-                        ImageViewEmbed? media1 = null;
+                        Embed? media1 = null;
 
                         if (doc.RootElement.TryGetProperty("record", out var recordVal2))
                         {
@@ -111,6 +111,9 @@ public class EmbedConverter : JsonConverter<Embed>
                                     case Constants.EmbedTypes.ImageView:
                                         media1 = JsonSerializer.Deserialize<ImageViewEmbed>(mediaVal2.GetRawText(), ((SourceGenerationContext)options.TypeInfoResolver!).ImageViewEmbed);
                                         break;
+                                    case Constants.EmbedTypes.VideoView:
+                                        media1 = JsonSerializer.Deserialize<VideoViewEmbed>(mediaVal2.GetRawText(), ((SourceGenerationContext)options.TypeInfoResolver!).VideoViewEmbed);
+                                        break;
                                 }
                             }
                         }
@@ -118,7 +121,7 @@ public class EmbedConverter : JsonConverter<Embed>
                         return new RecordWithMediaViewEmbed(record1, media1);
                     case Constants.EmbedTypes.RecordWithMedia:
                         RecordEmbed? record = null;
-                        ImagesEmbed? media = null;
+                        Embed? media = null;
 
                         if (doc.RootElement.TryGetProperty("record", out var recordVal))
                         {
@@ -134,6 +137,9 @@ public class EmbedConverter : JsonConverter<Embed>
                                 {
                                     case Constants.EmbedTypes.Images:
                                         media = JsonSerializer.Deserialize<ImagesEmbed>(mediaVal.GetRawText(), ((SourceGenerationContext)options.TypeInfoResolver!).ImagesEmbed);
+                                        break;
+                                    case Constants.EmbedTypes.VideoView:
+                                        media = JsonSerializer.Deserialize<VideoViewEmbed>(mediaVal.GetRawText(), ((SourceGenerationContext)options.TypeInfoResolver!).VideoViewEmbed);
                                         break;
                                 }
                             }


### PR DESCRIPTION
Honestly im not sure what is the difference between a VideoEmbedView and a RecordWithMedia/RecordWithMediaView, but I was developing a scrapper and while doing it, I came across a post (https://bsky.app/profile/mentales.com.br/post/3l5wxg6ih3u2s) that for some reason was being treated as a RecordWithMediaView and because of that, the video fields were not there, only the images. Not sure if this is going to break anything else, I can fix if it breaks please let me know.