### PR TITLE
Add more helper methods for facets

### DIFF
--- a/src/FishyFlip.Tests/AnonymousTests.cs
+++ b/src/FishyFlip.Tests/AnonymousTests.cs
@@ -118,4 +118,41 @@ public class AnonymousTests
         Assert.IsTrue(describe.Did is not null);
         Assert.AreEqual(describe.Did!.ToString(), repo.ToString());
     }
+
+    [TestMethod]
+    public async Task ValidateFacetHelpers()
+    {
+        var daDev = new FacetActorIdentifier(ATHandle.Create("drasticactions.dev")!, ATDid.Create("did:plc:okblbaji7rz243bluudjlgxt")!);
+        var daJp = new FacetActorIdentifier(ATHandle.Create("drasticactions.jp")!, ATDid.Create("did:plc:okblbaji7rz243bluudjl2bt")!);
+
+        var postText = "@drasticactions.dev This is a #test #test of #testing the #FishyFlip #API. https://github.com/drasticactions DAHome. @drasticactions.jp https://github.com/drasticactions/FishyFlip @drasticactions.dev Weee!";
+        var postHandles = ATHandle.FromPostText(postText);
+        Assert.IsTrue(postHandles.Length == 2);
+        Assert.IsTrue(postHandles[0].Handle == "drasticactions.dev");
+        Assert.IsTrue(postHandles[1].Handle == "drasticactions.jp");
+
+        var handleFacets = Facet.ForMentions(postText, new FacetActorIdentifier[] { daDev, daJp });
+
+        Assert.IsTrue(handleFacets.Length == 3);
+        Assert.IsTrue(handleFacets[0].Index!.ByteStart == 0);
+        Assert.IsTrue(handleFacets[0].Index!.ByteEnd == 19);
+        Assert.IsTrue(handleFacets[0].Features![0]!.Did! == daDev.Did);
+
+        Assert.IsTrue(handleFacets[1].Index!.ByteStart == 117);
+        Assert.IsTrue(handleFacets[1].Index!.ByteEnd == 135);
+        Assert.IsTrue(handleFacets[1].Features![0]!.Did! == daJp.Did);
+
+        Assert.IsTrue(handleFacets[2].Features![0]!.Did! == daDev.Did);
+        Assert.IsTrue(handleFacets[2].Index!.ByteStart == 180);
+        Assert.IsTrue(handleFacets[2].Index!.ByteEnd == 199);
+
+        var hashtagFacets = Facet.ForHashtags(postText);
+        Assert.IsTrue(hashtagFacets.Length == 5);
+        var uriFacets = Facet.ForUris(postText);
+        Assert.IsTrue(uriFacets.Length == 2);
+        var baseUriFacets = Facet.ForUris(postText, "DAHome", "https://github.com/drasticactions");
+        Assert.IsTrue(baseUriFacets.Length == 1);
+        var facets = handleFacets.Concat(hashtagFacets).Concat(uriFacets).Concat(baseUriFacets).ToArray();
+        Assert.IsTrue(facets.Length == 11);
+    }
 }

--- a/src/FishyFlip/Models/ATHandle.cs
+++ b/src/FishyFlip/Models/ATHandle.cs
@@ -71,7 +71,7 @@ public class ATHandle : ATIdentifier
     /// </summary>
     /// <param name="post">Text of the post.</param>
     /// <returns>Array of ATHandle.</returns>
-    public static ATHandle[] GetHandlesFromPostText(string post)
+    public static ATHandle[] FromPostText(string post)
     {
         var handles = new List<ATHandle>();
         var matches = Regex.Matches(post, @"@(?!http)[a-zA-Z0-9][-a-zA-Z0-9_.]{1,}");

--- a/src/FishyFlip/Models/ATHandle.cs
+++ b/src/FishyFlip/Models/ATHandle.cs
@@ -67,6 +67,38 @@ public class ATHandle : ATIdentifier
     }
 
     /// <summary>
+    /// Gets the handles from a post text.
+    /// </summary>
+    /// <param name="post">Text of the post.</param>
+    /// <returns>Array of ATHandle.</returns>
+    public static ATHandle[] GetHandlesFromPostText(string post)
+    {
+        var handles = new List<ATHandle>();
+        var matches = Regex.Matches(post, @"@(?!http)[a-zA-Z0-9][-a-zA-Z0-9_.]{1,}");
+        foreach (Match match in matches)
+        {
+            if (match.Success)
+            {
+                var handle = match.Value;
+                if (handle.StartsWith("@"))
+                {
+                    handle = handle.Substring(1);
+                }
+
+                if (HandleValidator.EnsureValidHandle(handle))
+                {
+                    if (!handles.Any(n => n.Handle == handle))
+                    {
+                        handles.Add(new ATHandle(handle));
+                    }
+                }
+            }
+        }
+
+        return handles.ToArray();
+    }
+
+    /// <summary>
     /// Is the given string a valid ATHandle.
     /// </summary>
     /// <param name="uri">The uri as string.</param>

--- a/src/FishyFlip/Models/Facet.cs
+++ b/src/FishyFlip/Models/Facet.cs
@@ -87,7 +87,7 @@ public class Facet : ATRecord
     /// </summary>
     /// <param name="post">Post text.</param>
     /// <returns>Array of Facets.</returns>
-    public static Facet[] CreateFacetsForUris(string post)
+    public static Facet[] ForUris(string post)
     {
         var facets = new List<Facet>();
         var matches = Regex.Matches(post, @"(https?://[^\s]+)");
@@ -109,7 +109,7 @@ public class Facet : ATRecord
     /// <param name="baseText">Text to embed with link.</param>
     /// <param name="uri">Link Uri.</param>
     /// <returns>Array of Facets.</returns>
-    public static Facet[] CreateFacetsForUris(string post, string baseText, string uri)
+    public static Facet[] ForUris(string post, string baseText, string uri)
     {
         var facets = new List<Facet>();
         var matches = Regex.Matches(post, baseText);
@@ -128,7 +128,7 @@ public class Facet : ATRecord
     /// </summary>
     /// <param name="post">Post text.</param>
     /// <returns>Array of Facets.</returns>
-    public static Facet[] CreateFacetsForHashtags(string post)
+    public static Facet[] ForHashtags(string post)
     {
         var facets = new List<Facet>();
 
@@ -162,7 +162,7 @@ public class Facet : ATRecord
     /// <param name="post">Post text.</param>
     /// <param name="actors">Array of actors profiles.</param>
     /// <returns>Array of Facets.</returns>
-    public static Facet[] CreateFacetsForMentions(string post, FacetActorIdentifier[] actors)
+    public static Facet[] ForMentions(string post, FacetActorIdentifier[] actors)
     {
         var facets = new List<Facet>();
 
@@ -199,7 +199,7 @@ public class Facet : ATRecord
     /// <param name="post">Post text.</param>
     /// <param name="actors">Actor profiles.</param>
     /// <returns>Array of Facets.</returns>
-    public static Facet[] CreateFacetsForMentions(string post, ActorProfile[] actors)
+    public static Facet[] ForMentions(string post, ActorProfile[] actors)
     {
         var actorList = new List<FacetActorIdentifier>();
         foreach (var actor in actors)
@@ -222,7 +222,7 @@ public class Facet : ATRecord
             actorList.Add(new FacetActorIdentifier(atHandle, actor.Did));
         }
 
-        return CreateFacetsForMentions(post, actorList.ToArray());
+        return ForMentions(post, actorList.ToArray());
     }
 
     /// <summary>
@@ -231,7 +231,7 @@ public class Facet : ATRecord
     /// <param name="post">Post text.</param>
     /// <param name="actors">Actor profiles.</param>
     /// <returns>Array of Facets.</returns>
-    public static Facet[] CreateFacetsForMentions(string post, FeedProfile[] actors)
+    public static Facet[] ForMentions(string post, FeedProfile[] actors)
     {
         var actorList = new List<FacetActorIdentifier>();
         foreach (var actor in actors)
@@ -254,7 +254,7 @@ public class Facet : ATRecord
             actorList.Add(new FacetActorIdentifier(atHandle, actor.Did));
         }
 
-        return CreateFacetsForMentions(post, actorList.ToArray());
+        return ForMentions(post, actorList.ToArray());
     }
 
     /// <summary>
@@ -263,6 +263,6 @@ public class Facet : ATRecord
     /// <param name="post">Post text.</param>
     /// <param name="actor">Actor profiles.</param>
     /// <returns>Array of Facets.</returns>
-    public static Facet[] CreateFacetsForMentions(string post, FeedProfile actor)
-        => CreateFacetsForMentions(post, new FeedProfile[] { actor });
+    public static Facet[] ForMentions(string post, FeedProfile actor)
+        => ForMentions(post, new FeedProfile[] { actor });
 }

--- a/src/FishyFlip/Models/Facet.cs
+++ b/src/FishyFlip/Models/Facet.cs
@@ -81,4 +81,188 @@ public class Facet : ATRecord
     /// <returns>The created facet.</returns>
     public static Facet CreateFacetMention(int start, int end, ATDid mention)
         => new(new FacetIndex(start, end), new FacetFeature[] { FacetFeature.CreateMention(mention) });
+
+    /// <summary>
+    /// Creates an array of facets with link features for the URIs in the specified post.
+    /// </summary>
+    /// <param name="post">Post text.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] CreateFacetsForUris(string post)
+    {
+        var facets = new List<Facet>();
+        var matches = Regex.Matches(post, @"(https?://[^\s]+)");
+        foreach (Match match in matches)
+        {
+            var start = match.Index;
+            var end = match.Index + match.Length;
+            var uri = match.Value;
+            facets.Add(CreateFacetLink(start, end, uri));
+        }
+
+        return facets.ToArray();
+    }
+
+    /// <summary>
+    /// Creates an array of facets with link features for the URIs in the specified post.
+    /// </summary>
+    /// <param name="post">Post text.</param>
+    /// <param name="baseText">Text to embed with link.</param>
+    /// <param name="uri">Link Uri.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] CreateFacetsForUris(string post, string baseText, string uri)
+    {
+        var facets = new List<Facet>();
+        var matches = Regex.Matches(post, baseText);
+        foreach (Match match in matches)
+        {
+            var start = match.Index;
+            var end = match.Index + match.Length;
+            facets.Add(CreateFacetLink(start, end, uri));
+        }
+
+        return facets.ToArray();
+    }
+
+    /// <summary>
+    /// Creates an array of facets with hashtag features for the hashtags in the specified post.
+    /// </summary>
+    /// <param name="post">Post text.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] CreateFacetsForHashtags(string post)
+    {
+        var facets = new List<Facet>();
+
+        // Match all hashtags in the post that are not part of a URL.
+        var matches = Regex.Matches(post, @"(?<![@\w/])#(?!\s)[\w\u0080-\uFFFF]+");
+        foreach (Match match in matches)
+        {
+            var start = match.Index;
+            var end = match.Index + match.Length;
+            var hashtag = match.Value;
+
+            if (hashtag.StartsWith("#"))
+            {
+                hashtag = hashtag.Substring(1);
+            }
+
+            if (string.IsNullOrEmpty(hashtag))
+            {
+                continue;
+            }
+
+            facets.Add(CreateFacetHashtag(start, end, hashtag));
+        }
+
+        return facets.ToArray();
+    }
+
+    /// <summary>
+    /// Creates an array of facets with mention features for the mentions in the specified post.
+    /// </summary>
+    /// <param name="post">Post text.</param>
+    /// <param name="actors">Array of actors profiles.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] CreateFacetsForMentions(string post, FacetActorIdentifier[] actors)
+    {
+        var facets = new List<Facet>();
+
+        // Match all mentions in the post that are not part of a URL.
+        var matches = Regex.Matches(post, @"@(?!http)[a-zA-Z0-9][-a-zA-Z0-9_.]{1,}");
+        foreach (Match match in matches)
+        {
+            var start = match.Index;
+            var end = match.Index + match.Length;
+            var mention = match.Value;
+            if (mention.StartsWith("@"))
+            {
+                mention = mention.Substring(1);
+            }
+
+            if (string.IsNullOrEmpty(mention))
+            {
+                continue;
+            }
+
+            var actor = actors.FirstOrDefault(n => n.Handle.ToString() == mention);
+            if (actor?.Did is not null)
+            {
+                facets.Add(CreateFacetMention(start, end, actor.Did));
+            }
+        }
+
+        return facets.ToArray();
+    }
+
+    /// <summary>
+    /// Creates an array of facets with mention features for the mentions in the specified post.
+    /// </summary>
+    /// <param name="post">Post text.</param>
+    /// <param name="actors">Actor profiles.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] CreateFacetsForMentions(string post, ActorProfile[] actors)
+    {
+        var actorList = new List<FacetActorIdentifier>();
+        foreach (var actor in actors)
+        {
+            if (actor.Handle is null)
+            {
+                continue;
+            }
+
+            if (!ATHandle.TryCreate(actor.Handle, out var atHandle))
+            {
+                continue;
+            }
+
+            if (atHandle is null || actor.Did is null)
+            {
+                continue;
+            }
+
+            actorList.Add(new FacetActorIdentifier(atHandle, actor.Did));
+        }
+
+        return CreateFacetsForMentions(post, actorList.ToArray());
+    }
+
+    /// <summary>
+    /// Creates an array of facets with mention features for the mentions in the specified post.
+    /// </summary>
+    /// <param name="post">Post text.</param>
+    /// <param name="actors">Actor profiles.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] CreateFacetsForMentions(string post, FeedProfile[] actors)
+    {
+        var actorList = new List<FacetActorIdentifier>();
+        foreach (var actor in actors)
+        {
+            if (actor.Handle is null)
+            {
+                continue;
+            }
+
+            if (!ATHandle.TryCreate(actor.Handle, out var atHandle))
+            {
+                continue;
+            }
+
+            if (atHandle is null || actor.Did is null)
+            {
+                continue;
+            }
+
+            actorList.Add(new FacetActorIdentifier(atHandle, actor.Did));
+        }
+
+        return CreateFacetsForMentions(post, actorList.ToArray());
+    }
+
+    /// <summary>
+    /// Creates an array of facets with mention features for the mentions in the specified post.
+    /// </summary>
+    /// <param name="post">Post text.</param>
+    /// <param name="actor">Actor profiles.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] CreateFacetsForMentions(string post, FeedProfile actor)
+        => CreateFacetsForMentions(post, new FeedProfile[] { actor });
 }

--- a/src/FishyFlip/Models/FacetActorIdentifier.cs
+++ b/src/FishyFlip/Models/FacetActorIdentifier.cs
@@ -1,0 +1,13 @@
+// <copyright file="FacetActorIdentifier.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Facet Actor Identifier, used to identify an actor in a facet to create a mention.
+/// The Handle and Did are not validated to be for the same actor.
+/// </summary>
+/// <param name="Handle"><see cref="ATHandle."/>.</param>
+/// <param name="Did"><see cref="ATDid"/>.</param>
+public record FacetActorIdentifier(ATHandle Handle, ATDid Did);


### PR DESCRIPTION
Addresses #68 

This creates additional helper methods for handling creating Facets, given a post text. 

```csharp
var postText = "@drasticactions.dev This is a #test #test of #testing the #FishyFlip #API. https://github.com/drasticactions DAHome. @drasticactions.jp https://github.com/drasticactions/FishyFlip @drasticactions.dev Weee!";
var postHandles = ATHandle.FromPostText(postText);
var feedProfiles = (await atProtocol.Actor.GetProfilesAsync(postHandles)).HandleResult();
var handleFacets = Facet.ForMentions(postText, feedProfiles!.Profiles!);
var hashtagFacets = Facet.ForHashtags(postText);
var uriFacets = Facet.ForUris(postText);
var baseUriFacets = Facet.ForUris(postText, "DAHome", "https://github.com/drasticactions");
var facets = handleFacets.Concat(hashtagFacets).Concat(uriFacets).Concat(baseUriFacets).ToArray();
var result = (await atProtocol.Repo.CreatePostAsync(postText, facets)).HandleResult();
```

https://bsky.app/profile/drasticactions.xn--q9jyb4c/post/3l7n4vrnoqx2k

<img width="594" alt="image" src="https://github.com/user-attachments/assets/307a0ed8-8269-474a-bafd-d876a347e946">
