### PR TITLE
Add MarkdownPost

### DIFF
--- a/src/FishyFlip.Tests/AnonymousTests.cs
+++ b/src/FishyFlip.Tests/AnonymousTests.cs
@@ -120,6 +120,28 @@ public class AnonymousTests
     }
 
     [TestMethod]
+    public void MarkdownPostTest()
+    {
+        var markdownPost = @"Markdown Test: [FishyFlip](https://drasticactions.github.io/FishyFlip), #FishyFlip, [@drasticactions.dev](did:plc:yhgc5rlqhoezrx6fbawajxlh)";
+        var post = MarkdownPost.Parse(markdownPost);
+        Assert.IsTrue(post.OriginalMarkdown == markdownPost);
+        Assert.IsTrue(post.Post == "Markdown Test: FishyFlip, #FishyFlip, @drasticactions.dev");
+        Assert.IsTrue(post.Facets.Length == 3);
+        Assert.IsTrue(post.Facets[0].Features![0]!.Type == Constants.FacetTypes.Link);
+        Assert.IsTrue(post.Facets[0].Features![0]!.Uri == "https://drasticactions.github.io/FishyFlip");
+        Assert.IsTrue(post.Facets[0].Index!.ByteStart == 15);
+        Assert.IsTrue(post.Facets[0].Index!.ByteEnd == 24);
+        Assert.IsTrue(post.Facets[1].Features![0]!.Type == Constants.FacetTypes.Mention);
+        Assert.IsTrue(post.Facets[1].Features![0]!.Did!.ToString() == "did:plc:yhgc5rlqhoezrx6fbawajxlh");
+        Assert.IsTrue(post.Facets[1].Index!.ByteStart == 38);
+        Assert.IsTrue(post.Facets[1].Index!.ByteEnd == 57);
+        Assert.IsTrue(post.Facets[2].Features![0]!.Type == Constants.FacetTypes.Tag);
+        Assert.IsTrue(post.Facets[2].Features![0]!.Tag == "FishyFlip");
+        Assert.IsTrue(post.Facets[2].Index!.ByteStart == 26);
+        Assert.IsTrue(post.Facets[2].Index!.ByteEnd == 36);
+    }
+
+    [TestMethod]
     public async Task ValidateFacetHelpers()
     {
         var daDev = new FacetActorIdentifier(ATHandle.Create("drasticactions.dev")!, ATDid.Create("did:plc:okblbaji7rz243bluudjlgxt")!);

--- a/src/FishyFlip/Models/Facet.cs
+++ b/src/FishyFlip/Models/Facet.cs
@@ -265,4 +265,14 @@ public class Facet : ATRecord
     /// <returns>Array of Facets.</returns>
     public static Facet[] ForMentions(string post, FeedProfile actor)
         => ForMentions(post, new FeedProfile[] { actor });
+
+    /// <summary>
+    /// Returns a string that represents the current object.
+    /// </summary>
+    /// <returns>String.</returns>
+    public override string ToString()
+    {
+        var features = this.Features ?? Array.Empty<FacetFeature>();
+        return $"Facet: {this.Index}, Features: {string.Join(", ", features.Select(f => f.ToString()))}";
+    }
 }

--- a/src/FishyFlip/Models/FacetFeature.cs
+++ b/src/FishyFlip/Models/FacetFeature.cs
@@ -81,4 +81,19 @@ public class FacetFeature
     /// <returns>A new instance of the <see cref="FacetFeature"/> class.</returns>
     public static FacetFeature CreateHashtag(string tag)
         => new(Constants.FacetTypes.Tag, null, tag, null);
+
+    /// <summary>
+    /// Returns a string that represents the current object.
+    /// </summary>
+    /// <returns>String.</returns>
+    public override string ToString()
+    {
+        return this.Type switch
+        {
+            Constants.FacetTypes.Link => $"Link: {this.Uri}",
+            Constants.FacetTypes.Mention => $"Mention: {this.Did}",
+            Constants.FacetTypes.Tag => $"Tag: {this.Tag}",
+            _ => "Unknown",
+        };
+    }
 }

--- a/src/FishyFlip/Models/FacetIndex.cs
+++ b/src/FishyFlip/Models/FacetIndex.cs
@@ -40,4 +40,13 @@ public class FacetIndex
     /// Gets the starting byte position of the facet.
     /// </summary>
     public int ByteStart { get; }
+
+    /// <summary>
+    /// Returns a string that represents the current object.
+    /// </summary>
+    /// <returns>String.</returns>
+    public override string ToString()
+    {
+        return $"ByteStart: {this.ByteStart}, ByteEnd: {this.ByteEnd}";
+    }
 }

--- a/src/FishyFlip/Models/MarkdownPost.cs
+++ b/src/FishyFlip/Models/MarkdownPost.cs
@@ -1,0 +1,190 @@
+// <copyright file="MarkdownPost.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Markdown Post.
+/// Converts a markdown string into a post.
+/// </summary>
+public class MarkdownPost
+{
+    private MarkdownPost(string markdown)
+    {
+        this.OriginalMarkdown = markdown;
+        this.Post = StripMarkdown(markdown);
+        var links = ExtractLinks(markdown);
+        var facets = GetFacetLinks(links);
+        var hashtagFacets = Facet.ForHashtags(this.Post);
+        this.Facets = facets.Concat(hashtagFacets).ToArray();
+    }
+
+    /// <summary>
+    /// Gets the post content, with no markdown.
+    /// </summary>
+    public string Post { get; private set; }
+
+    /// <summary>
+    /// Gets the original markdown.
+    /// </summary>
+    public string OriginalMarkdown { get; private set; }
+
+    /// <summary>
+    /// Gets the facets in the post.
+    /// </summary>
+    public Facet[] Facets { get; private set; }
+
+    /// <summary>
+    /// Parse a markdown string into a post.
+    /// </summary>
+    /// <param name="markdown">Markdown.</param>
+    /// <returns><see cref="MarkdownPost"/>.</returns>
+    public static MarkdownPost Parse(string markdown)
+    {
+        return new MarkdownPost(markdown);
+    }
+
+    private static Facet[] GetFacetLinks(MarkdownLink[] links)
+    {
+        if (links == null || links.Length == 0)
+        {
+            return Array.Empty<Facet>();
+        }
+
+        var facets = new List<Facet>();
+        foreach (var link in links)
+        {
+            if (Uri.TryCreate(link.Url, UriKind.Absolute, out Uri? uri))
+            {
+                // If link is an did:pcl, create a mention facet
+                if (uri.Scheme == "did")
+                {
+                    if (ATDid.TryCreate(uri.ToString(), out ATDid? did))
+                    {
+                        facets.Add(Facet.CreateFacetMention(link.StartIndex, link.EndIndex, did!));
+                    }
+                }
+                else
+                {
+                    facets.Add(Facet.CreateFacetLink(link.StartIndex, link.EndIndex, uri.ToString()));
+                }
+            }
+        }
+
+        return facets.ToArray();
+    }
+
+    private static string StripMarkdown(string markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return string.Empty;
+        }
+
+        // Headers
+        markdown = Regex.Replace(markdown, @"^#+\s*", string.Empty, RegexOptions.Multiline);
+
+        // Bold and Italic
+        markdown = Regex.Replace(markdown, @"[*_]{1,3}(.*?)[*_]{1,3}", "$1");
+
+        // Code blocks with language specification
+        markdown = Regex.Replace(markdown, @"```[\w-]*\n(.*?)\n```", "$1", RegexOptions.Singleline);
+
+        // Inline code
+        markdown = Regex.Replace(markdown, @"`([^`]+)`", "$1");
+
+        // Links [text](url)
+        markdown = Regex.Replace(markdown, @"\[([^\]]+)\]\([^\)]+\)", "$1");
+
+        // Images ![alt](url)
+        markdown = Regex.Replace(markdown, @"!\[[^\]]*\]\([^\)]+\)", string.Empty);
+
+        // Blockquotes
+        markdown = Regex.Replace(markdown, @"^\s*>\s*", string.Empty, RegexOptions.Multiline);
+
+        // Unordered lists
+        markdown = Regex.Replace(markdown, @"^\s*[-*+]\s+", string.Empty, RegexOptions.Multiline);
+
+        // Ordered lists
+        markdown = Regex.Replace(markdown, @"^\s*\d+\.\s+", string.Empty, RegexOptions.Multiline);
+
+        // Horizontal rules
+        markdown = Regex.Replace(markdown, @"^\s*[-*_]{3,}\s*$", string.Empty, RegexOptions.Multiline);
+
+        // Strikethrough
+        markdown = Regex.Replace(markdown, @"~~(.*?)~~", "$1");
+
+        // Clean up extra whitespace
+        markdown = Regex.Replace(markdown, @"\n{3,}", "\n\n");
+        markdown = markdown.Trim();
+
+        return markdown;
+    }
+
+    private static MarkdownLink[] ExtractLinks(string markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return Array.Empty<MarkdownLink>();
+        }
+
+        var links = new List<MarkdownLink>();
+        var strippedMarkdown = StripMarkdown(markdown);
+
+        // Regular expression to match Markdown links, excluding image links
+        var linkRegex = new Regex(@"(?<!!)\[([^\]]+)\]\(([^\)]+)\)");
+
+        var matches = linkRegex.Matches(markdown);
+
+        foreach (Match match in matches)
+        {
+            var text = match.Groups[1].Value;
+            var url = match.Groups[2].Value;
+
+            // Find where this text appears in the final stripped version
+            var textStartIndex = strippedMarkdown.IndexOf(text);
+
+            // Create the link object with indices based on where the text would appear
+            // in the fully stripped version
+            links.Add(new MarkdownLink(
+                text: text,
+                url: url,
+                startIndex: textStartIndex,
+                endIndex: textStartIndex + text.Length));
+        }
+
+        return links.ToArray();
+    }
+
+    private class MarkdownLink
+    {
+        public MarkdownLink(string text, string url, int startIndex, int endIndex)
+        {
+            this.Text = text;
+            this.Url = url;
+            this.StartIndex = startIndex;
+            this.EndIndex = endIndex;
+        }
+
+        /// <summary>
+        /// Gets the text of the link.
+        /// </summary>
+        public string Text { get; }
+
+        /// <summary>
+        /// Gets the url of the link.
+        /// </summary>
+        public string Url { get; }
+
+        /// <summary>
+        /// Gets the start index of the link.
+        /// </summary>
+        public int StartIndex { get; }
+
+        /// <summary>
+        /// Gets the end index of the link.
+        /// </summary>
+        public int EndIndex { get; }
+    }
+}


### PR DESCRIPTION
`MarkdownPost` is a helper class for creating a post with `Facet` values out of Markdown. This can be useful if you want to easily allow for CLI applications to create posts with links, mentions, and hashtags.

```
Markdown Test: [FishyFlip](https://drasticactions.github.io/FishyFlip), #FishyFlip, [@drasticactions.dev](did:plc:yhgc5rlqhoezrx6fbawajxlh)
```

Will return

```
Markdown Test: FishyFlip, #FishyFlip, @drasticactions.dev
```

with a Link Facet, a Hashtag facet, and a mention facet. Note that mention facets do _not_ require `@` handles. ATProtocol does not validate them, so these methods don't either.