### PR TITLE
Update deprecated fields

### DIFF
--- a/samples/Jetstream/Program.cs
+++ b/samples/Jetstream/Program.cs
@@ -21,7 +21,7 @@ atWebProtocol.OnConnectionUpdated += (sender, args) =>
 
 atWebProtocol.OnRecordReceived += (sender, args) =>
 {
-    Console.WriteLine($"Record Received: {args.Record.Type}");
+    Console.WriteLine($"Record Received: {args.Record.Kind}");
 };
 
 await atWebProtocol.ConnectAsync();

--- a/src/FishyFlip/Models/ATWebSocketCommit.cs
+++ b/src/FishyFlip/Models/ATWebSocketCommit.cs
@@ -13,15 +13,15 @@ public class ATWebSocketCommit
     /// Initializes a new instance of the <see cref="ATWebSocketCommit"/> class.
     /// </summary>
     /// <param name="rev">The revision identifier.</param>
-    /// <param name="type">The type of the WebSocket commit.</param>
+    /// <param name="operation">The type of the WebSocket commit.</param>
     /// <param name="collection">The collection name.</param>
     /// <param name="rKey">The record key.</param>
     /// <param name="record">The record associated with the commit.</param>
     /// <param name="cid">The CID associated with the commit.</param>
-    public ATWebSocketCommit(string? rev, ATWebSocketCommitType type, string? collection, string? rKey, ATRecord? record, ATCid? cid)
+    public ATWebSocketCommit(string? rev, ATWebSocketCommitType operation, string? collection, string? rKey, ATRecord? record, ATCid? cid)
     {
         this.Rev = rev;
-        this.Type = type;
+        this.Operation = operation;
         this.Collection = collection;
         this.RKey = rKey;
         this.Record = record;
@@ -36,7 +36,13 @@ public class ATWebSocketCommit
     /// <summary>
     /// Gets the type of the WebSocket commit.
     /// </summary>
-    public ATWebSocketCommitType Type { get; }
+    public ATWebSocketCommitType Operation { get; }
+
+    /// <summary>
+    /// Gets the type of the WebSocket commit.
+    /// </summary>
+    [Obsolete("Use Operation instead.")]
+    public ATWebSocketCommitType Type => this.Operation;
 
     /// <summary>
     /// Gets the collection name.

--- a/src/FishyFlip/Models/ATWebSocketRecord.cs
+++ b/src/FishyFlip/Models/ATWebSocketRecord.cs
@@ -12,15 +12,15 @@ public class ATWebSocketRecord
     /// <summary>
     /// Initializes a new instance of the <see cref="ATWebSocketRecord"/> class.
     /// </summary>
-    /// <param name="type">Type.</param>
+    /// <param name="kind">Type.</param>
     /// <param name="did">Did.</param>
     /// <param name="commit">Commit.</param>
     /// <param name="identity">Identity.</param>
     /// <param name="account">Account.</param>
     [JsonConstructor]
-    public ATWebSocketRecord(ATWebSocketEvent type, ATDid? did, ATWebSocketCommit? commit, ActorIdentity? identity, ActorAccount? account)
+    public ATWebSocketRecord(ATWebSocketEvent kind, ATDid? did, ATWebSocketCommit? commit, ActorIdentity? identity, ActorAccount? account)
     {
-        this.Type = type;
+        this.Kind = kind;
         this.Did = did;
         this.Commit = commit;
         this.Identity = identity;
@@ -30,7 +30,13 @@ public class ATWebSocketRecord
     /// <summary>
     /// Gets the Type.
     /// </summary>
-    public ATWebSocketEvent Type { get; }
+    public ATWebSocketEvent Kind { get; }
+
+    /// <summary>
+    /// Gets the Type.
+    /// </summary>
+    [Obsolete("Use Kind instead.")]
+    public ATWebSocketEvent Type => this.Kind;
 
     /// <summary>
     /// Gets the Commit.

--- a/src/FishyFlip/Tools/Json/ATWebSocketCommitTypeConverter.cs
+++ b/src/FishyFlip/Tools/Json/ATWebSocketCommitTypeConverter.cs
@@ -20,11 +20,11 @@ public class ATWebSocketCommitTypeConverter : JsonConverter<ATWebSocketCommitTyp
 
         switch (value)
         {
-            case "u":
+            case "update":
                 return ATWebSocketCommitType.Update;
-            case "c":
+            case "create":
                 return ATWebSocketCommitType.Create;
-            case "d":
+            case "delete":
                 return ATWebSocketCommitType.Delete;
             default:
                 return ATWebSocketCommitType.Unknown;

--- a/src/FishyFlip/Tools/Json/ATWebSocketEventConverter.cs
+++ b/src/FishyFlip/Tools/Json/ATWebSocketEventConverter.cs
@@ -20,11 +20,11 @@ public class ATWebSocketEventConverter : JsonConverter<ATWebSocketEvent>
 
         switch (value)
         {
-            case "com":
+            case "commit":
                 return ATWebSocketEvent.Commit;
-            case "acc":
+            case "account":
                 return ATWebSocketEvent.Account;
-            case "id":
+            case "identity":
                 return ATWebSocketEvent.Identity;
             default:
                 return ATWebSocketEvent.Unknown;


### PR DESCRIPTION
This addresses the following change to jetstream which deprecates the type fields. As of today the fields are no longer present on the events

https://github.com/bluesky-social/jetstream/pull/7
> This change updates the event struct to be more human-readable now that we support compression and don't need to save characters as greedily.
> 
> Motivation behind this change is to make the event stream readable for someone without having to go lookup docs on event structure. Some existing fields have been a bit cryptic with naming and with value abbreviations, making the stream less understandable to new developers.
> 
> Deprecated fields:
> 
>     * `event.type` -> `event.kind`
>       
>       * `com, id, acc` -> `commit, identity, account`
> 
>     * `commit.type` -> `commit.operation`
>       
>       * `c, u, d` -> `create, update, delete`
> 
> 
> To support backwards compatibility for a brief window, the old fields and values will still be emitted during a migration window.

https://github.com/bluesky-social/jetstream/pull/13