### PR TITLE
Don't set ATError object when logging errors with PasswordSession

### DIFF
--- a/src/FishyFlip/PasswordSessionManager.cs
+++ b/src/FishyFlip/PasswordSessionManager.cs
@@ -136,7 +136,7 @@ internal class PasswordSessionManager : ISessionManager
 
             this.SetSession(session);
         },
-            e => this.logger?.LogError(e.ToString(), e));
+            e => this.logger?.LogError(e.ToString()));
 
         return resultSession;
     }
@@ -215,7 +215,7 @@ internal class PasswordSessionManager : ISessionManager
                     this.SetSession,
                     e =>
                     {
-                        this.logger?.LogError(e.ToString(), e);
+                        this.logger?.LogError(e.ToString());
                     });
             }
             else


### PR DESCRIPTION
Fixes #86 

ATError doesn't like being deserialized by Microsoft.Extensions.Logging. As it's already present as a `ToString` we don't need to include the object as well.