### PR TITLE
Fixes issue with ListNotificationsAsync not honouring seenAt date

### DIFF
--- a/src/FishyFlip/BlueskyNotification.cs
+++ b/src/FishyFlip/BlueskyNotification.cs
@@ -74,7 +74,7 @@ public sealed class BlueskyNotification
         var url = Constants.Urls.Bluesky.Notification.NotificationListNotifications + $"?limit={limit}";
         if (seenAt is not null)
         {
-            url += $"?seenAt={seenAt.Value.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture)}";
+            url += $"&seenAt={seenAt.Value.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture)}";
         }
 
         if (cursor is not null)


### PR DESCRIPTION
The `seenAt` query is incorrectly being appended with a `?` instead of `&` as the query string already contains a `?limit` query