### PR TITLE
Expose the Cursor on the NotificationCollection

### DIFF
--- a/src/FishyFlip/Models/NotificationCollection.cs
+++ b/src/FishyFlip/Models/NotificationCollection.cs
@@ -7,4 +7,4 @@ namespace FishyFlip.Models;
 /// <summary>
 /// Represents a collection of notifications.
 /// </summary>
-public record NotificationCollection(Notification[] Notifications);
+public record NotificationCollection(Notification[] Notifications, string Cursor);


### PR DESCRIPTION
When calling `ListNotificationsAsync` it is possible to pass a `cursor` parameter, however the `NotificationCollection` doesn't expose the cursor value that is returned from the endpoint. This PR exposes that value so that you can effectively paginate notifications.