### PR TITLE
Disable AutomaticDecompression for WASM

### DIFF
--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -81,10 +81,27 @@ public class ATProtocolOptions
     /// <returns><see cref="HttpClient"/>.</returns>
     internal HttpClient GenerateHttpClient(HttpMessageHandler? handler = default)
     {
-        var httpClient = new HttpClient(handler ?? new HttpClientHandler { MaxRequestContentBufferSize = int.MaxValue, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate, });
+#if NET8_0_OR_GREATER
+        bool isBrowser = OperatingSystem.IsBrowser();
+#else
+        bool isBrowser = false;
+#endif
+        if (isBrowser)
+        {
+            handler ??= new HttpClientHandler();
+        }
+        else
+        {
+            handler ??= new HttpClientHandler { MaxRequestContentBufferSize = int.MaxValue, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+        }
+
+        var httpClient = new HttpClient(handler);
         httpClient.DefaultRequestHeaders.Add(Constants.HeaderNames.UserAgent, this.UserAgent);
         httpClient.DefaultRequestHeaders.Add("Accept", Constants.AcceptedMediaType);
         httpClient.BaseAddress = this.Url;
+#if NET8_0_OR_GREATER
+        httpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+#endif
         return httpClient;
     }
 }


### PR DESCRIPTION
Hello, I started making a simple BlueSky client on Blazor WebAssembly using FishyFlip.

The current version of the library crashes because it tries to set the property `HttpClientHandler.AutomaticDecompression`, which is not supported on WASM. I removed that property and now it works perfectly. If you want, you could add an explicit target for "net9.0-browser" which would warn you if you ever add anything incompatible.

I also added `DefaultVersionPolicy = RequestVersionOrHigher` to enable HTTP/2 and HTTP/3, which are disabled by default. This should increase performance for simultaneous requests if the server supports it.