### PR TITLE
Add errors sourcegen

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="DotMake.CommandLine" Version="1.8.7" />
     <PackageVersion Include="IdentityModel.OidcClient" Version="6.0.0" />
     <PackageVersion Include="IdentityModel.OidcClient.DPoP" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />

--- a/tools/FFSourceGen/FFSourceGen.csproj
+++ b/tools/FFSourceGen/FFSourceGen.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adding this as /xrpc/ api response errors of statuscode 400 have defined possible values.

Two parts to this
1. When main.errors exists, generate a `{ClassName}Errors` enum with the defined values at the same level as `{ClassName}`
  1.a. Figure it's better to keep it on the same level rather than as a subclass since subclasses are annoying to use without static imports
  1.b. There are also other possible values that appear common across all responses being `InvalidRequest`,`ExpiredToken`, and `InvalidToken`, I think it's best to exclude these however since they aren't explicitly defined in the lexicon but rather are part of the lexicon query docs https://github.com/bluesky-social/bsky-docs/blob/b64c7398979fd4e50009842f387f6c2eb3471f5f/atproto-openapi-types/lib/converters/query.ts#L73 
2. Run generated stringbuilder output through syntax sourcetree to format it in a standard way (this may prove easier than manually setting up indentation across all of program.cs)

I'll let you run the generation at your own leisure as 2. makes minor modifications to all of the generated files and I want to avoid dumping a 400+ file pr on you 