### PR TITLE
Add ToString override for ATError

### DIFF
--- a/src/FishyFlip/Models/ATError.cs
+++ b/src/FishyFlip/Models/ATError.cs
@@ -39,4 +39,13 @@ public class ATError
     /// </summary>
     [JsonPropertyName("detail")]
     public ErrorDetail? Detail { get; set; }
+
+    /// <summary>
+    /// ToString override.
+    /// </summary>
+    /// <returns>String.</returns>
+    public override string ToString()
+    {
+        return $"StatusCode: {this.StatusCode}, {this.Detail}";
+    }
 }

--- a/src/FishyFlip/Models/ErrorDetail.cs
+++ b/src/FishyFlip/Models/ErrorDetail.cs
@@ -38,4 +38,13 @@ public class ErrorDetail
     /// </summary>
     [JsonPropertyName("message")]
     public string? Message { get; set; }
+
+    /// <summary>
+    /// ToString override.
+    /// </summary>
+    /// <returns>String.</returns>
+    public override string ToString()
+    {
+        return $"{this.Error} - {this.Message}";
+    }
 }


### PR DESCRIPTION
Switching ATError from Record to Class removed the nice ToString formatting. This brings it back.