### PR TITLE
Resolve Repo DIDs and Handles independently

### DIFF
--- a/src/FishyFlip/ATProtocol.cs
+++ b/src/FishyFlip/ATProtocol.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 
+using FishyFlip.Lexicon.Com.Atproto.Identity;
+
 namespace FishyFlip;
 
 /// <summary>
@@ -13,7 +15,6 @@ public sealed partial class ATProtocol : IDisposable
     private ATProtocolOptions options;
     private bool disposedValue;
     private ISessionManager sessionManager;
-    private Dictionary<string, string> didCache = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ATProtocol"/> class.
@@ -209,6 +210,73 @@ public sealed partial class ATProtocol : IDisposable
     }
 
     /// <summary>
+    /// Resolves an ATHandle to a host address.
+    /// </summary>
+    /// <param name="handle"><see cref="ATHandle"/>.</param>
+    /// <param name="token">Cancellation Token.</param>
+    /// <returns>String of Host URI if it could be resolved, null if it could not.</returns>
+    public async Task<string?> ResolveATHandleHostAsync(ATHandle handle, CancellationToken? token = default)
+    {
+        string? host = this.options.DidCache.FirstOrDefault(n => n.Key == handle.ToString()).Value;
+        try
+        {
+            if (!string.IsNullOrEmpty(host))
+            {
+                this.options.Logger?.LogDebug($"Resolved handle from cache: {handle} to {host}");
+                return host;
+            }
+
+            if (this.IsAuthenticated && this.Session?.Handle.ToString() == handle.ToString())
+            {
+                host = this.Session?.DidDoc?.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
+                if (!string.IsNullOrEmpty(host))
+                {
+                    this.options.DidCache[handle.ToString()] = host!;
+                    this.options.Logger?.LogDebug($"Resolved handle: {handle} to {host}, adding to cache.");
+                }
+                else
+                {
+                    this.options.Logger?.LogError($"Failed to resolve Self User handle: {handle}, missing Service Handle.");
+                }
+            }
+
+            var endpointUrl = $"{Constants.Urls.ATProtoServer.SocialApi}{IdentityEndpoints.ResolveHandle}?handle={handle}";
+            var result = await this.Client.GetAsync(endpointUrl, token ?? CancellationToken.None);
+            if (result.IsSuccessStatusCode)
+            {
+                var resolveHandle = JsonSerializer.Deserialize<ResolveHandleOutput>(await result.Content.ReadAsStringAsync(), this.options.SourceGenerationContext.ComAtprotoIdentityResolveHandleOutput);
+                if (resolveHandle?.Did is not null)
+                {
+                    host = await this.ResolveATDidHostAsync(resolveHandle.Did, token);
+                    if (!string.IsNullOrEmpty(host))
+                    {
+                        this.options.DidCache[handle.ToString()] = host!;
+                        this.options.Logger?.LogDebug($"Resolved handle: {handle} to {host}, adding to cache.");
+                    }
+                    else
+                    {
+                        this.options.Logger?.LogError($"Failed to resolve Handle: {handle}, missing Service Handle.");
+                    }
+                }
+                else
+                {
+                    this.options.Logger?.LogError($"Failed to resolve Handle: {handle}. Missing DID.");
+                }
+            }
+            else
+            {
+                this.options.Logger?.LogError($"Failed to resolve Handle: {handle}. {result.StatusCode}");
+            }
+        }
+        catch (Exception ex)
+        {
+            this.options.Logger?.LogError($"Failed to resolve Handle: {handle}. {ex.Message}");
+        }
+
+        return host;
+    }
+
+    /// <summary>
     /// Resolves an ATDid to a host address.
     /// </summary>
     /// <param name="did"><see cref="ATDid"/>.</param>
@@ -216,100 +284,107 @@ public sealed partial class ATProtocol : IDisposable
     /// <returns>String of Host URI if it could be resolved, null if it could not.</returns>
     public async Task<string?> ResolveATDidHostAsync(ATDid did, CancellationToken? token = default)
     {
-        string? host = this.didCache.FirstOrDefault(n => n.Key == did.ToString()).Value;
-        if (!string.IsNullOrEmpty(host))
+        string? host = this.options.DidCache.FirstOrDefault(n => n.Key == did.ToString()).Value;
+        try
         {
-            this.options.Logger?.LogDebug($"Resolved DID from cache: {did} to {host}");
-            return host;
-        }
+            if (!string.IsNullOrEmpty(host))
+            {
+                this.options.Logger?.LogDebug($"Resolved DID from cache: {did} to {host}");
+                return host;
+            }
 
-        switch (did.Type)
-        {
-            case "plc":
-                if (this.IsAuthenticated && this.Session?.Did.ToString() == did.ToString())
-                {
-                    host = this.Session?.DidDoc?.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
-                    if (!string.IsNullOrEmpty(host))
+            switch (did.Type)
+            {
+                case "plc":
+                    if (this.IsAuthenticated && this.Session?.Did.ToString() == did.ToString())
                     {
-                        this.didCache.Add(did.ToString(), host!);
-                        this.options.Logger?.LogDebug($"Resolved DID: {did} to {host}, adding to cache.");
-                    }
-                    else
-                    {
-                        this.options.Logger?.LogError($"Failed to resolve Self User DID: {did}, missing Service Handle.");
-                    }
-                }
-
-                var (resolveHandle, error) = await this.PlcDirectory.GetDidDocAsync(did!);
-                if (resolveHandle is not null)
-                {
-                    var resultHost = resolveHandle.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
-                    if (!string.IsNullOrEmpty(resultHost))
-                    {
-                        host = resultHost!;
-                    }
-                    else
-                    {
-                        this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing Service Handle.");
-                    }
-                }
-                else
-                {
-                    this.options.Logger?.LogError($"Failed to resolve plc DID: {did}. {error?.ToString()}");
-                }
-
-                break;
-            case "web":
-                var baseUri = did.ToString().Split(':').Last();
-                if (!baseUri.Contains("http"))
-                {
-                    baseUri = $"https://{baseUri}";
-                }
-
-                if (Uri.TryCreate(baseUri, UriKind.Absolute, out var uri))
-                {
-                    var resolveUri = uri.ToString();
-                    var result = await this.Client.GetAsync($"{resolveUri}{Constants.DidJson}");
-                    if (result.IsSuccessStatusCode)
-                    {
-                        var didDoc = JsonSerializer.Deserialize<DidDoc>(await result.Content.ReadAsStringAsync(), this.options.SourceGenerationContext.DidDoc);
-                        if (didDoc is not null)
+                        host = this.Session?.DidDoc?.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
+                        if (!string.IsNullOrEmpty(host))
                         {
-                            var resultHost = didDoc.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
-                            if (!string.IsNullOrEmpty(resultHost))
+                            this.options.DidCache[did.ToString()] = host!;
+                            this.options.Logger?.LogDebug($"Resolved DID: {did} to {host}, adding to cache.");
+                        }
+                        else
+                        {
+                            this.options.Logger?.LogError($"Failed to resolve Self User DID: {did}, missing Service Handle.");
+                        }
+                    }
+
+                    var (resolveHandle, error) = await this.PlcDirectory.GetDidDocAsync(did!, token ?? CancellationToken.None);
+                    if (resolveHandle is not null)
+                    {
+                        var resultHost = resolveHandle.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
+                        if (!string.IsNullOrEmpty(resultHost))
+                        {
+                            host = resultHost!;
+                        }
+                        else
+                        {
+                            this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing Service Handle.");
+                        }
+                    }
+                    else
+                    {
+                        this.options.Logger?.LogError($"Failed to resolve plc DID: {did}. {error?.ToString()}");
+                    }
+
+                    break;
+                case "web":
+                    var baseUri = did.ToString().Split(':').Last();
+                    if (!baseUri.Contains("http"))
+                    {
+                        baseUri = $"https://{baseUri}";
+                    }
+
+                    if (Uri.TryCreate(baseUri, UriKind.Absolute, out var uri))
+                    {
+                        var resolveUri = uri.ToString();
+                        var result = await this.Client.GetAsync($"{resolveUri}{Constants.DidJson}", token ?? CancellationToken.None);
+                        if (result.IsSuccessStatusCode)
+                        {
+                            var didDoc = JsonSerializer.Deserialize<DidDoc>(await result.Content.ReadAsStringAsync(), this.options.SourceGenerationContext.DidDoc);
+                            if (didDoc is not null)
                             {
-                                host = resultHost!;
+                                var resultHost = didDoc.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
+                                if (!string.IsNullOrEmpty(resultHost))
+                                {
+                                    host = resultHost!;
+                                }
+                                else
+                                {
+                                    this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing Service Handle.");
+                                }
                             }
                             else
                             {
-                                this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing Service Handle.");
+                                this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing DID Doc.");
                             }
                         }
                         else
                         {
-                            this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing DID Doc.");
+                            this.options.Logger?.LogError($"Failed to resolve web DID: {did}.");
                         }
                     }
                     else
                     {
                         this.options.Logger?.LogError($"Failed to resolve web DID: {did}.");
                     }
-                }
-                else
-                {
-                    this.options.Logger?.LogError($"Failed to resolve web DID: {did}.");
-                }
 
-                break;
-            default:
-                this.options.Logger?.LogError($"DID type could not be resolved: {did}");
-                break;
+                    break;
+                default:
+                    this.options.Logger?.LogError($"DID type could not be resolved: {did}");
+                    break;
+            }
+
+            if (!string.IsNullOrEmpty(host))
+            {
+                this.options.DidCache[did.ToString()] = host!;
+                this.options.Logger?.LogDebug($"Resolved DID: {did} to {host}, adding to cache.");
+            }
         }
-
-        if (!string.IsNullOrEmpty(host))
+        catch (Exception ex)
         {
-            this.didCache.Add(did.ToString(), host!);
-            this.options.Logger?.LogDebug($"Resolved DID: {did} to {host}, adding to cache.");
+            this.options.Logger?.LogError($"Failed to resolve DID: {did}. {ex.Message}");
         }
 
         return host;

--- a/src/FishyFlip/ATProtocolBuilder.cs
+++ b/src/FishyFlip/ATProtocolBuilder.cs
@@ -86,6 +86,38 @@ public class ATProtocolBuilder
     }
 
     /// <summary>
+    /// Adds a cache set of ATDid values with their respective service endpoint URIs.
+    /// Use this to cache the service endpoints for the ATDid values to avoid having to look them up.
+    /// </summary>
+    /// <param name="didCache">Cache values.</param>
+    /// <returns><see cref="ATProtocolBuilder"/>.</returns>
+    public ATProtocolBuilder WithATDidCache(Dictionary<ATDid, Uri> didCache)
+    {
+        foreach (var item in didCache)
+        {
+            this.atProtocolOptions.DidCache[item.Key.ToString()] = item.Value.ToString();
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a cache set of ATHandle values with their respective service endpoint URIs.
+    /// Use this to cache the service endpoints for the ATHandle values to avoid having to look them up.
+    /// </summary>
+    /// <param name="didCache">Cache values.</param>
+    /// <returns><see cref="ATProtocolBuilder"/>.</returns>
+    public ATProtocolBuilder WithATHandleCache(Dictionary<ATHandle, Uri> didCache)
+    {
+        foreach (var item in didCache)
+        {
+            this.atProtocolOptions.DidCache[item.Key.ToString()] = item.Value.ToString();
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Sets the session refresh interval.
     /// </summary>
     /// <param name="interval">Interval to refresh at.</param>

--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -104,7 +104,6 @@ public class ATProtocolOptions
 
         httpClient.DefaultRequestHeaders.Add(Constants.HeaderNames.UserAgent, this.UserAgent);
         httpClient.DefaultRequestHeaders.Add("Accept", Constants.AcceptedMediaType);
-        httpClient.BaseAddress = this.Url;
 #if NET8_0_OR_GREATER
         // From https://github.com/drasticactions/FishyFlip/pull/107
         httpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;

--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -70,6 +70,11 @@ public class ATProtocolOptions
     public bool UseServiceEndpointUponLogin { get; internal set; } = true;
 
     /// <summary>
+    /// Gets the Did Cache.
+    /// </summary>
+    internal Dictionary<string, string> DidCache { get; } = new Dictionary<string, string>();
+
+    /// <summary>
     /// Gets the source generation context.
     /// </summary>
     internal SourceGenerationContext SourceGenerationContext { get; }

--- a/src/FishyFlip/Constants.cs
+++ b/src/FishyFlip/Constants.cs
@@ -7,6 +7,8 @@ namespace FishyFlip;
 #pragma warning disable SA1600 // Elements should be documented
 public static class Constants
 {
+    internal const string DidJson = ".well-known/did.json";
+    internal const string AtprotoPersonalDataServer = "AtprotoPersonalDataServer";
     internal const string BlueskyApiClient = "FishyFlip";
     internal const string ContentMediaType = "application/json";
     internal const string AcceptedMediaType = "application/json";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ActorEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ActorEndpoints.g.cs
@@ -37,7 +37,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Actor.GetPreferencesOutput?>> GetPreferencesAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetPreferences.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Actor.GetPreferencesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorGetPreferencesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Actor.GetPreferencesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorGetPreferencesOutput!, cancellationToken);
         }
 
 
@@ -56,7 +56,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
             queryStrings.Add("actor=" + actor);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorProfileViewDetailed!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorProfileViewDetailed!, cancellationToken);
         }
 
 
@@ -75,7 +75,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
             queryStrings.Add(string.Join("&", actors.Select(n => "actors=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Actor.GetProfilesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorGetProfilesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Actor.GetProfilesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorGetProfilesOutput!, cancellationToken);
         }
 
 
@@ -103,7 +103,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Actor.GetSuggestionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorGetSuggestionsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Actor.GetSuggestionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorGetSuggestionsOutput!, cancellationToken);
         }
 
 
@@ -133,7 +133,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
             var endpointUrl = PutPreferences.ToString();
             var inputItem = new PutPreferencesInput();
             inputItem.Preferences = preferences;
-            return atp.Client.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -167,7 +167,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorSearchActorsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorSearchActorsOutput!, cancellationToken);
         }
 
 
@@ -195,7 +195,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsTypeaheadOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorSearchActorsTypeaheadOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsTypeaheadOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorSearchActorsTypeaheadOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedEndpoints.g.cs
@@ -59,7 +59,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Feed.DescribeFeedGeneratorOutput?>> DescribeFeedGeneratorAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DescribeFeedGenerator.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.DescribeFeedGeneratorOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedDescribeFeedGeneratorOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.DescribeFeedGeneratorOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedDescribeFeedGeneratorOutput!, cancellationToken);
         }
 
 
@@ -90,7 +90,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetActorFeedsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetActorFeedsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetActorFeedsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetActorFeedsOutput!, cancellationToken);
         }
 
 
@@ -124,7 +124,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetActorLikesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetActorLikesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetActorLikesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetActorLikesOutput!, cancellationToken);
         }
 
 
@@ -170,7 +170,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetAuthorFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetAuthorFeedOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetAuthorFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetAuthorFeedOutput!, cancellationToken);
         }
 
 
@@ -203,7 +203,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedOutput!, cancellationToken);
         }
 
 
@@ -222,7 +222,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             queryStrings.Add("feed=" + feed);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedGeneratorOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedGeneratorOutput!, cancellationToken);
         }
 
 
@@ -241,7 +241,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             queryStrings.Add(string.Join("&", feeds.Select(n => "feeds=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedGeneratorsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedGeneratorsOutput!, cancellationToken);
         }
 
 
@@ -274,7 +274,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedSkeletonOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetFeedSkeletonOutput!, cancellationToken);
         }
 
 
@@ -311,7 +311,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetLikesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetLikesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetLikesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetLikesOutput!, cancellationToken);
         }
 
 
@@ -344,7 +344,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetListFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetListFeedOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetListFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetListFeedOutput!, cancellationToken);
         }
 
 
@@ -363,7 +363,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             queryStrings.Add(string.Join("&", uris.Select(n => "uris=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetPostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetPostsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetPostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetPostsOutput!, cancellationToken);
         }
 
 
@@ -396,7 +396,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetPostThreadOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetPostThreadOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetPostThreadOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetPostThreadOutput!, cancellationToken);
         }
 
 
@@ -433,7 +433,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetQuotesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetQuotesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetQuotesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetQuotesOutput!, cancellationToken);
         }
 
 
@@ -470,7 +470,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetRepostedByOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetRepostedByOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetRepostedByOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetRepostedByOutput!, cancellationToken);
         }
 
 
@@ -498,7 +498,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetSuggestedFeedsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetSuggestedFeedsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetSuggestedFeedsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetSuggestedFeedsOutput!, cancellationToken);
         }
 
 
@@ -532,7 +532,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetTimelineOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetTimelineOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.GetTimelineOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedGetTimelineOutput!, cancellationToken);
         }
 
 
@@ -619,7 +619,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Feed.SearchPostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedSearchPostsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Feed.SearchPostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedSearchPostsOutput!, cancellationToken);
         }
 
 
@@ -635,7 +635,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
             var endpointUrl = SendInteractions.ToString();
             var inputItem = new SendInteractionsInput();
             inputItem.Interactions = interactions;
-            return atp.Client.Post<SendInteractionsInput, FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsInput!, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<SendInteractionsInput, FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsInput!, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsOutput!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GraphEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GraphEndpoints.g.cs
@@ -83,7 +83,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetActorStarterPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetActorStarterPacksOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetActorStarterPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetActorStarterPacksOutput!, cancellationToken);
         }
 
 
@@ -111,7 +111,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetBlocksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetBlocksOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetBlocksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetBlocksOutput!, cancellationToken);
         }
 
 
@@ -142,7 +142,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowersOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetFollowersOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowersOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetFollowersOutput!, cancellationToken);
         }
 
 
@@ -173,7 +173,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetFollowsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetFollowsOutput!, cancellationToken);
         }
 
 
@@ -204,7 +204,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetKnownFollowersOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetKnownFollowersOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetKnownFollowersOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetKnownFollowersOutput!, cancellationToken);
         }
 
 
@@ -235,7 +235,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListOutput!, cancellationToken);
         }
 
 
@@ -263,7 +263,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListBlocksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListBlocksOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListBlocksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListBlocksOutput!, cancellationToken);
         }
 
 
@@ -291,7 +291,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListMutesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListMutesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListMutesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListMutesOutput!, cancellationToken);
         }
 
 
@@ -322,7 +322,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetListsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetListsOutput!, cancellationToken);
         }
 
 
@@ -350,7 +350,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetMutesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetMutesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetMutesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetMutesOutput!, cancellationToken);
         }
 
 
@@ -377,7 +377,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetRelationshipsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetRelationshipsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetRelationshipsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetRelationshipsOutput!, cancellationToken);
         }
 
 
@@ -396,7 +396,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             queryStrings.Add("starterPack=" + starterPack);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPackOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetStarterPackOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPackOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetStarterPackOutput!, cancellationToken);
         }
 
 
@@ -415,7 +415,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             queryStrings.Add(string.Join("&", uris.Select(n => "uris=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetStarterPacksOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetStarterPacksOutput!, cancellationToken);
         }
 
 
@@ -434,7 +434,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             queryStrings.Add("actor=" + actor);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetSuggestedFollowsByActorOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetSuggestedFollowsByActorOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.GetSuggestedFollowsByActorOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphGetSuggestedFollowsByActorOutput!, cancellationToken);
         }
 
 
@@ -450,7 +450,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             var endpointUrl = MuteActor.ToString();
             var inputItem = new MuteActorInput();
             inputItem.Actor = actor;
-            return atp.Client.Post<MuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<MuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -466,7 +466,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             var endpointUrl = MuteActorList.ToString();
             var inputItem = new MuteActorListInput();
             inputItem.List = list;
-            return atp.Client.Post<MuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorListInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<MuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorListInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -482,7 +482,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             var endpointUrl = MuteThread.ToString();
             var inputItem = new MuteThreadInput();
             inputItem.Root = root;
-            return atp.Client.Post<MuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteThreadInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<MuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteThreadInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -513,7 +513,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Graph.SearchStarterPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphSearchStarterPacksOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Graph.SearchStarterPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphSearchStarterPacksOutput!, cancellationToken);
         }
 
 
@@ -529,7 +529,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             var endpointUrl = UnmuteActor.ToString();
             var inputItem = new UnmuteActorInput();
             inputItem.Actor = actor;
-            return atp.Client.Post<UnmuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UnmuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -545,7 +545,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             var endpointUrl = UnmuteActorList.ToString();
             var inputItem = new UnmuteActorListInput();
             inputItem.List = list;
-            return atp.Client.Post<UnmuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorListInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UnmuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorListInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -561,7 +561,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
             var endpointUrl = UnmuteThread.ToString();
             var inputItem = new UnmuteThreadInput();
             inputItem.Root = root;
-            return atp.Client.Post<UnmuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteThreadInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UnmuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteThreadInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerEndpoints.g.cs
@@ -37,7 +37,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Labeler.GetServicesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyLabelerGetServicesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Labeler.GetServicesOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyLabelerGetServicesOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Notification/NotificationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Notification/NotificationEndpoints.g.cs
@@ -48,7 +48,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Notification.GetUnreadCountOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationGetUnreadCountOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Notification.GetUnreadCountOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationGetUnreadCountOutput!, cancellationToken);
         }
 
 
@@ -88,7 +88,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Notification.ListNotificationsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationListNotificationsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Notification.ListNotificationsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationListNotificationsOutput!, cancellationToken);
         }
 
 
@@ -104,7 +104,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
             var endpointUrl = PutPreferences.ToString();
             var inputItem = new PutPreferencesInput();
             inputItem.Priority = priority;
-            return atp.Client.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -126,7 +126,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
             inputItem.Token = token;
             inputItem.Platform = platform;
             inputItem.AppId = appId;
-            return atp.Client.Post<RegisterPushInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationRegisterPushInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<RegisterPushInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationRegisterPushInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -142,7 +142,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
             var endpointUrl = UpdateSeen.ToString();
             var inputItem = new UpdateSeenInput();
             inputItem.SeenAt = seenAt;
-            return atp.Client.Post<UpdateSeenInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationUpdateSeenInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateSeenInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationUpdateSeenInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/UnspeccedEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/UnspeccedEndpoints.g.cs
@@ -37,7 +37,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Unspecced.GetConfigOutput?>> GetConfigAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetConfig.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetConfigOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetConfigOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetConfigOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetConfigOutput!, cancellationToken);
         }
 
 
@@ -71,7 +71,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetPopularFeedGeneratorsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetPopularFeedGeneratorsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetPopularFeedGeneratorsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetPopularFeedGeneratorsOutput!, cancellationToken);
         }
 
 
@@ -111,7 +111,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestionsSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetSuggestionsSkeletonOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestionsSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetSuggestionsSkeletonOutput!, cancellationToken);
         }
 
 
@@ -124,7 +124,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTaggedSuggestionsOutput?>> GetTaggedSuggestionsAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetTaggedSuggestions.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTaggedSuggestionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetTaggedSuggestionsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTaggedSuggestionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedGetTaggedSuggestionsOutput!, cancellationToken);
         }
 
 
@@ -169,7 +169,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchActorsSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedSearchActorsSkeletonOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchActorsSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedSearchActorsSkeletonOutput!, cancellationToken);
         }
 
 
@@ -262,7 +262,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchPostsSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedSearchPostsSkeletonOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchPostsSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedSearchPostsSkeletonOutput!, cancellationToken);
         }
 
 
@@ -301,7 +301,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchStarterPacksSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedSearchStarterPacksSkeletonOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchStarterPacksSkeletonOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyUnspeccedSearchStarterPacksSkeletonOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Video/VideoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Video/VideoEndpoints.g.cs
@@ -35,7 +35,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Video
             queryStrings.Add("jobId=" + jobId);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Video.GetJobStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoGetJobStatusOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Video.GetJobStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoGetJobStatusOutput!, cancellationToken);
         }
 
 
@@ -48,7 +48,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Video
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Video.GetUploadLimitsOutput?>> GetUploadLimitsAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetUploadLimits.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.App.Bsky.Video.GetUploadLimitsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoGetUploadLimitsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.App.Bsky.Video.GetUploadLimitsOutput>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoGetUploadLimitsOutput!, cancellationToken);
         }
 
 
@@ -61,7 +61,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Video
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput?>> UploadVideoAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UploadVideo.ToString();
-            return atp.Client.Post<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoUploadVideoOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoUploadVideoOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ActorEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ActorEndpoints.g.cs
@@ -27,7 +27,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput?>> DeleteAccountAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteAccount.ToString();
-            return atp.Client.Post<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyActorDeleteAccountOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyActorDeleteAccountOutput!, cancellationToken);
         }
 
 
@@ -40,7 +40,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         public static Task<Result<Success?>> ExportAccountDataAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ExportAccountData.ToString();
-            return atp.Client.Get<Success>(endpointUrl, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<Success>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoEndpoints.g.cs
@@ -52,7 +52,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             var inputItem = new DeleteMessageForSelfInput();
             inputItem.ConvoId = convoId;
             inputItem.MessageId = messageId;
-            return atp.Client.Post<DeleteMessageForSelfInput, FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoDeleteMessageForSelfInput!, atp.Options.SourceGenerationContext.ChatBskyConvoDeletedMessageView!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteMessageForSelfInput, FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoDeleteMessageForSelfInput!, atp.Options.SourceGenerationContext.ChatBskyConvoDeletedMessageView!, inputItem, cancellationToken);
         }
 
 
@@ -71,7 +71,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             queryStrings.Add("convoId=" + convoId);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetConvoOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetConvoOutput!, cancellationToken);
         }
 
 
@@ -90,7 +90,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             queryStrings.Add(string.Join("&", members.Select(n => "members=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoForMembersOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetConvoForMembersOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoForMembersOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetConvoForMembersOutput!, cancellationToken);
         }
 
 
@@ -112,7 +112,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetLogOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetLogOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetLogOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetLogOutput!, cancellationToken);
         }
 
 
@@ -143,7 +143,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetMessagesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetMessagesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.GetMessagesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoGetMessagesOutput!, cancellationToken);
         }
 
 
@@ -159,7 +159,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             var endpointUrl = LeaveConvo.ToString();
             var inputItem = new LeaveConvoInput();
             inputItem.ConvoId = convoId;
-            return atp.Client.Post<LeaveConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<LeaveConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoOutput!, inputItem, cancellationToken);
         }
 
 
@@ -187,7 +187,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.ListConvosOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoListConvosOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Convo.ListConvosOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoListConvosOutput!, cancellationToken);
         }
 
 
@@ -203,7 +203,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             var endpointUrl = MuteConvo.ToString();
             var inputItem = new MuteConvoInput();
             inputItem.ConvoId = convoId;
-            return atp.Client.Post<MuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<MuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoOutput!, inputItem, cancellationToken);
         }
 
 
@@ -221,7 +221,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             var inputItem = new SendMessageInput();
             inputItem.ConvoId = convoId;
             inputItem.Message = message;
-            return atp.Client.Post<SendMessageInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMessageView!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<SendMessageInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMessageView!, inputItem, cancellationToken);
         }
 
 
@@ -237,7 +237,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             var endpointUrl = SendMessageBatch.ToString();
             var inputItem = new SendMessageBatchInput();
             inputItem.Items = items;
-            return atp.Client.Post<SendMessageBatchInput, FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchInput!, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<SendMessageBatchInput, FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchInput!, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchOutput!, inputItem, cancellationToken);
         }
 
 
@@ -253,7 +253,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             var endpointUrl = UnmuteConvo.ToString();
             var inputItem = new UnmuteConvoInput();
             inputItem.ConvoId = convoId;
-            return atp.Client.Post<UnmuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UnmuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoOutput!, inputItem, cancellationToken);
         }
 
 
@@ -271,7 +271,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
             var inputItem = new UpdateReadInput();
             inputItem.ConvoId = convoId;
             inputItem.MessageId = messageId;
-            return atp.Client.Post<UpdateReadInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateReadInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadOutput!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
@@ -35,7 +35,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
             queryStrings.Add("actor=" + actor);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetActorMetadataOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationGetActorMetadataOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetActorMetadataOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationGetActorMetadataOutput!, cancellationToken);
         }
 
 
@@ -72,7 +72,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetMessageContextOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationGetMessageContextOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetMessageContextOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationGetMessageContextOutput!, cancellationToken);
         }
 
 
@@ -92,7 +92,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
             inputItem.Actor = actor;
             inputItem.AllowAccess = allowAccess;
             inputItem.Ref = @ref;
-            return atp.Client.Post<UpdateActorAccessInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationUpdateActorAccessInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateActorAccessInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationUpdateActorAccessInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
@@ -54,7 +54,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var endpointUrl = DeleteAccount.ToString();
             var inputItem = new DeleteAccountInput();
             inputItem.Did = did;
-            return atp.Client.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -72,7 +72,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var inputItem = new DisableAccountInvitesInput();
             inputItem.Account = account;
             inputItem.Note = note;
-            return atp.Client.Post<DisableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DisableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -90,7 +90,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var inputItem = new DisableInviteCodesInput();
             inputItem.Codes = codes;
             inputItem.Accounts = accounts;
-            return atp.Client.Post<DisableInviteCodesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableInviteCodesInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DisableInviteCodesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableInviteCodesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -108,7 +108,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var inputItem = new EnableAccountInvitesInput();
             inputItem.Account = account;
             inputItem.Note = note;
-            return atp.Client.Post<EnableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminEnableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<EnableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminEnableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -127,7 +127,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             queryStrings.Add("did=" + did);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Admin.AccountView>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminAccountView!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.AccountView>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminAccountView!, cancellationToken);
         }
 
 
@@ -146,7 +146,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             queryStrings.Add(string.Join("&", dids.Select(n => "dids=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetAccountInfosOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetAccountInfosOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetAccountInfosOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetAccountInfosOutput!, cancellationToken);
         }
 
 
@@ -180,7 +180,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetInviteCodesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetInviteCodesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetInviteCodesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetInviteCodesOutput!, cancellationToken);
         }
 
 
@@ -214,7 +214,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetSubjectStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetSubjectStatusOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetSubjectStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetSubjectStatusOutput!, cancellationToken);
         }
 
 
@@ -248,7 +248,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Admin.SearchAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminSearchAccountsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.SearchAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminSearchAccountsOutput!, cancellationToken);
         }
 
 
@@ -272,7 +272,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             inputItem.SenderDid = senderDid;
             inputItem.Subject = subject;
             inputItem.Comment = comment;
-            return atp.Client.Post<SendEmailInput, FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<SendEmailInput, FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailOutput!, inputItem, cancellationToken);
         }
 
 
@@ -290,7 +290,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var inputItem = new UpdateAccountEmailInput();
             inputItem.Account = account;
             inputItem.Email = email;
-            return atp.Client.Post<UpdateAccountEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountEmailInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateAccountEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -308,7 +308,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var inputItem = new UpdateAccountHandleInput();
             inputItem.Did = did;
             inputItem.Handle = handle;
-            return atp.Client.Post<UpdateAccountHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountHandleInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateAccountHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountHandleInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -326,7 +326,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var inputItem = new UpdateAccountPasswordInput();
             inputItem.Did = did;
             inputItem.Password = password;
-            return atp.Client.Post<UpdateAccountPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountPasswordInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateAccountPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -346,7 +346,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             inputItem.Subject = subject;
             inputItem.Takedown = takedown;
             inputItem.Deactivated = deactivated;
-            return atp.Client.Post<UpdateSubjectStatusInput, FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateSubjectStatusInput, FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusOutput!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Identity/IdentityEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Identity/IdentityEndpoints.g.cs
@@ -35,7 +35,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Identity.GetRecommendedDidCredentialsOutput?>> GetRecommendedDidCredentialsAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetRecommendedDidCredentials.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Identity.GetRecommendedDidCredentialsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityGetRecommendedDidCredentialsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Identity.GetRecommendedDidCredentialsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityGetRecommendedDidCredentialsOutput!, cancellationToken);
         }
 
 
@@ -48,7 +48,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         public static Task<Result<Success?>> RequestPlcOperationSignatureAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestPlcOperationSignature.ToString();
-            return atp.Client.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
         }
 
 
@@ -67,7 +67,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
             queryStrings.Add("handle=" + handle);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveHandleOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityResolveHandleOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveHandleOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityResolveHandleOutput!, cancellationToken);
         }
 
 
@@ -91,7 +91,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
             inputItem.AlsoKnownAs = alsoKnownAs;
             inputItem.VerificationMethods = verificationMethods;
             inputItem.Services = services;
-            return atp.Client.Post<SignPlcOperationInput, FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationInput!, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<SignPlcOperationInput, FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationInput!, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationOutput!, inputItem, cancellationToken);
         }
 
 
@@ -107,7 +107,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
             var endpointUrl = SubmitPlcOperation.ToString();
             var inputItem = new SubmitPlcOperationInput();
             inputItem.Operation = operation;
-            return atp.Client.Post<SubmitPlcOperationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySubmitPlcOperationInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<SubmitPlcOperationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySubmitPlcOperationInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -123,7 +123,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
             var endpointUrl = UpdateHandle.ToString();
             var inputItem = new UpdateHandleInput();
             inputItem.Handle = handle;
-            return atp.Client.Post<UpdateHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityUpdateHandleInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityUpdateHandleInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Label/LabelEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Label/LabelEndpoints.g.cs
@@ -49,7 +49,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Label.QueryLabelsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoLabelQueryLabelsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Label.QueryLabelsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoLabelQueryLabelsOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
@@ -41,7 +41,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Moderation
             inputItem.ReasonType = reasonType;
             inputItem.Subject = subject;
             inputItem.Reason = reason;
-            return atp.Client.Post<CreateReportInput, FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportInput!, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateReportInput, FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportInput!, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportOutput!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/RepoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/RepoEndpoints.g.cs
@@ -54,7 +54,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             inputItem.Writes = writes;
             inputItem.Validate = validate;
             inputItem.SwapCommit = swapCommit;
-            return atp.Client.Post<ApplyWritesInput, FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<ApplyWritesInput, FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesOutput!, inputItem, cancellationToken);
         }
 
 
@@ -82,7 +82,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             inputItem.Rkey = rkey;
             inputItem.Validate = validate;
             inputItem.SwapCommit = swapCommit;
-            return atp.Client.Post<CreateRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordOutput!, inputItem, cancellationToken);
         }
 
 
@@ -108,7 +108,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             inputItem.Rkey = rkey;
             inputItem.SwapRecord = swapRecord;
             inputItem.SwapCommit = swapCommit;
-            return atp.Client.Post<DeleteRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordOutput!, inputItem, cancellationToken);
         }
 
 
@@ -127,7 +127,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             queryStrings.Add("repo=" + repo);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Repo.DescribeRepoOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoDescribeRepoOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.DescribeRepoOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoDescribeRepoOutput!, cancellationToken);
         }
 
 
@@ -160,7 +160,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Repo.GetRecordOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoGetRecordOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.GetRecordOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoGetRecordOutput!, cancellationToken);
         }
 
 
@@ -174,7 +174,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<Success?>> ImportRepoAsync (this FishyFlip.ATProtocol atp, StreamContent content, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ImportRepo.ToString();
-            return atp.Client.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, content, cancellationToken, atp.Options.Logger);
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, content, cancellationToken);
         }
 
 
@@ -202,7 +202,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Repo.ListMissingBlobsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoListMissingBlobsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.ListMissingBlobsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoListMissingBlobsOutput!, cancellationToken);
         }
 
 
@@ -242,7 +242,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Repo.ListRecordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoListRecordsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.ListRecordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoListRecordsOutput!, cancellationToken);
         }
 
 
@@ -272,7 +272,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             inputItem.Validate = validate;
             inputItem.SwapRecord = swapRecord;
             inputItem.SwapCommit = swapCommit;
-            return atp.Client.Post<PutRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<PutRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordOutput!, inputItem, cancellationToken);
         }
 
 
@@ -286,7 +286,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput?>> UploadBlobAsync (this FishyFlip.ATProtocol atp, StreamContent content, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UploadBlob.ToString();
-            return atp.Client.Post<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoUploadBlobOutput!, atp.Options.JsonSerializerOptions, content, cancellationToken, atp.Options.Logger);
+            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoUploadBlobOutput!, content, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/ServerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/ServerEndpoints.g.cs
@@ -73,7 +73,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> ActivateAccountAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ActivateAccount.ToString();
-            return atp.Client.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
         }
 
 
@@ -86,7 +86,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.CheckAccountStatusOutput?>> CheckAccountStatusAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CheckAccountStatus.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Server.CheckAccountStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCheckAccountStatusOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.CheckAccountStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCheckAccountStatusOutput!, cancellationToken);
         }
 
 
@@ -109,7 +109,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var inputItem = new ConfirmEmailInput();
             inputItem.Email = email;
             inputItem.Token = token;
-            return atp.Client.Post<ConfirmEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerConfirmEmailInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<ConfirmEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerConfirmEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -149,7 +149,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             inputItem.Password = password;
             inputItem.RecoveryKey = recoveryKey;
             inputItem.PlcOp = plcOp;
-            return atp.Client.Post<CreateAccountInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateAccountInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountOutput!, inputItem, cancellationToken);
         }
 
 
@@ -169,7 +169,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var inputItem = new CreateAppPasswordInput();
             inputItem.Name = name;
             inputItem.Privileged = privileged;
-            return atp.Client.Post<CreateAppPasswordInput, FishyFlip.Lexicon.Com.Atproto.Server.AppPasswordDef?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAppPasswordInput!, atp.Options.SourceGenerationContext.ComAtprotoServerAppPasswordDef!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateAppPasswordInput, FishyFlip.Lexicon.Com.Atproto.Server.AppPasswordDef?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAppPasswordInput!, atp.Options.SourceGenerationContext.ComAtprotoServerAppPasswordDef!, inputItem, cancellationToken);
         }
 
 
@@ -187,7 +187,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var inputItem = new CreateInviteCodeInput();
             inputItem.UseCount = useCount;
             inputItem.ForAccount = forAccount;
-            return atp.Client.Post<CreateInviteCodeInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateInviteCodeInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeOutput!, inputItem, cancellationToken);
         }
 
 
@@ -207,7 +207,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             inputItem.CodeCount = codeCount;
             inputItem.UseCount = useCount;
             inputItem.ForAccounts = forAccounts;
-            return atp.Client.Post<CreateInviteCodesInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateInviteCodesInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesOutput!, inputItem, cancellationToken);
         }
 
 
@@ -230,7 +230,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             inputItem.Identifier = identifier;
             inputItem.Password = password;
             inputItem.AuthFactorToken = authFactorToken;
-            return atp.Client.Post<CreateSessionInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateSessionInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionOutput!, inputItem, cancellationToken);
         }
 
 
@@ -246,7 +246,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var endpointUrl = DeactivateAccount.ToString();
             var inputItem = new DeactivateAccountInput();
             inputItem.DeleteAfter = deleteAfter;
-            return atp.Client.Post<DeactivateAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeactivateAccountInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeactivateAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeactivateAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -269,7 +269,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             inputItem.Did = did;
             inputItem.Password = password;
             inputItem.Token = token;
-            return atp.Client.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -282,7 +282,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> DeleteSessionAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteSession.ToString();
-            return atp.Client.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
         }
 
 
@@ -295,7 +295,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.DescribeServerOutput?>> DescribeServerAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DescribeServer.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Server.DescribeServerOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDescribeServerOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.DescribeServerOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDescribeServerOutput!, cancellationToken);
         }
 
 
@@ -325,7 +325,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetAccountInviteCodesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetAccountInviteCodesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetAccountInviteCodesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetAccountInviteCodesOutput!, cancellationToken);
         }
 
 
@@ -358,7 +358,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetServiceAuthOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetServiceAuthOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetServiceAuthOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetServiceAuthOutput!, cancellationToken);
         }
 
 
@@ -371,7 +371,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.GetSessionOutput?>> GetSessionAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetSession.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetSessionOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetSessionOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetSessionOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetSessionOutput!, cancellationToken);
         }
 
 
@@ -386,7 +386,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.ListAppPasswordsOutput?>> ListAppPasswordsAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ListAppPasswords.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Server.ListAppPasswordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerListAppPasswordsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.ListAppPasswordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerListAppPasswordsOutput!, cancellationToken);
         }
 
 
@@ -401,7 +401,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput?>> RefreshSessionAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RefreshSession.ToString();
-            return atp.Client.Post<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRefreshSessionOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRefreshSessionOutput!, cancellationToken);
         }
 
 
@@ -414,7 +414,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> RequestAccountDeleteAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestAccountDelete.ToString();
-            return atp.Client.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
         }
 
 
@@ -427,7 +427,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> RequestEmailConfirmationAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestEmailConfirmation.ToString();
-            return atp.Client.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
         }
 
 
@@ -440,7 +440,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput?>> RequestEmailUpdateAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestEmailUpdate.ToString();
-            return atp.Client.Post<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestEmailUpdateOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestEmailUpdateOutput!, cancellationToken);
         }
 
 
@@ -456,7 +456,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var endpointUrl = RequestPasswordReset.ToString();
             var inputItem = new RequestPasswordResetInput();
             inputItem.Email = email;
-            return atp.Client.Post<RequestPasswordResetInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestPasswordResetInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<RequestPasswordResetInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestPasswordResetInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -472,7 +472,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var endpointUrl = ReserveSigningKey.ToString();
             var inputItem = new ReserveSigningKeyInput();
             inputItem.Did = did;
-            return atp.Client.Post<ReserveSigningKeyInput, FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyInput!, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<ReserveSigningKeyInput, FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyInput!, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyOutput!, inputItem, cancellationToken);
         }
 
 
@@ -493,7 +493,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var inputItem = new ResetPasswordInput();
             inputItem.Token = token;
             inputItem.Password = password;
-            return atp.Client.Post<ResetPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerResetPasswordInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<ResetPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerResetPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -509,7 +509,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             var endpointUrl = RevokeAppPassword.ToString();
             var inputItem = new RevokeAppPasswordInput();
             inputItem.Name = name;
-            return atp.Client.Post<RevokeAppPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRevokeAppPasswordInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<RevokeAppPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRevokeAppPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -533,7 +533,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             inputItem.Email = email;
             inputItem.EmailAuthFactor = emailAuthFactor;
             inputItem.Token = token;
-            return atp.Client.Post<UpdateEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerUpdateEmailInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerUpdateEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
@@ -58,7 +58,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("cid=" + cid);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.GetBlob(endpointUrl, SourceGenerationContext.Default.Options, cancellationToken, atp.Options.Logger);
+            return atp.GetBlob(endpointUrl, cancellationToken);
         }
 
 
@@ -89,7 +89,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("onDecoded=" + onDecoded);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.GetCarAsync(endpointUrl, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger, onDecoded);
+            return atp.GetCarAsync(endpointUrl, cancellationToken, onDecoded);
         }
 
 
@@ -113,7 +113,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("did=" + did);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Sync.GetLatestCommitOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncGetLatestCommitOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.GetLatestCommitOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncGetLatestCommitOutput!, cancellationToken);
         }
 
 
@@ -147,7 +147,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("onDecoded=" + onDecoded);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.GetCarAsync(endpointUrl, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger, onDecoded);
+            return atp.GetCarAsync(endpointUrl, cancellationToken, onDecoded);
         }
 
 
@@ -180,7 +180,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.GetCarAsync(endpointUrl, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger, onDecoded);
+            return atp.GetCarAsync(endpointUrl, cancellationToken, onDecoded);
         }
 
 
@@ -201,7 +201,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("did=" + did);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Sync.GetRepoStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncGetRepoStatusOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.GetRepoStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncGetRepoStatusOutput!, cancellationToken);
         }
 
 
@@ -243,7 +243,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListBlobsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListBlobsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListBlobsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListBlobsOutput!, cancellationToken);
         }
 
 
@@ -271,7 +271,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListReposOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListReposOutput!, cancellationToken);
         }
 
 
@@ -287,7 +287,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             var endpointUrl = NotifyOfUpdate.ToString();
             var inputItem = new NotifyOfUpdateInput();
             inputItem.Hostname = hostname;
-            return atp.Client.Post<NotifyOfUpdateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncNotifyOfUpdateInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<NotifyOfUpdateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncNotifyOfUpdateInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -303,7 +303,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             var endpointUrl = RequestCrawl.ToString();
             var inputItem = new RequestCrawlInput();
             inputItem.Hostname = hostname;
-            return atp.Client.Post<RequestCrawlInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncRequestCrawlInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<RequestCrawlInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncRequestCrawlInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Temp/TempEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Temp/TempEndpoints.g.cs
@@ -32,7 +32,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
             var endpointUrl = AddReservedHandle.ToString();
             var inputItem = new AddReservedHandleInput();
             inputItem.Handle = handle;
-            return atp.Client.Post<AddReservedHandleInput, FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleInput!, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<AddReservedHandleInput, FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleInput!, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleOutput!, inputItem, cancellationToken);
         }
 
 
@@ -45,7 +45,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Temp.CheckSignupQueueOutput?>> CheckSignupQueueAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CheckSignupQueue.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Atproto.Temp.CheckSignupQueueOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempCheckSignupQueueOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Atproto.Temp.CheckSignupQueueOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempCheckSignupQueueOutput!, cancellationToken);
         }
 
 
@@ -61,7 +61,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
             var endpointUrl = RequestPhoneVerification.ToString();
             var inputItem = new RequestPhoneVerificationInput();
             inputItem.PhoneNumber = phoneNumber;
-            return atp.Client.Post<RequestPhoneVerificationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempRequestPhoneVerificationInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<RequestPhoneVerificationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempRequestPhoneVerificationInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEndpoints.g.cs
@@ -37,7 +37,7 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
             queryStrings.Add("author=" + author);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetAuthorPostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetAuthorPostsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetAuthorPostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetAuthorPostsOutput!, cancellationToken);
         }
 
 
@@ -61,7 +61,7 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
             queryStrings.Add("entryTitle=" + entryTitle);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetEntryMetadataByNameOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetEntryMetadataByNameOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetEntryMetadataByNameOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetEntryMetadataByNameOutput!, cancellationToken);
         }
 
 
@@ -80,7 +80,7 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
             queryStrings.Add("postUri=" + postUri);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetMentionsByEntryOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetMentionsByEntryOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetMentionsByEntryOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetMentionsByEntryOutput!, cancellationToken);
         }
 
 
@@ -96,7 +96,7 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
             var endpointUrl = NotifyOfNewEntry.ToString();
             var inputItem = new NotifyOfNewEntryInput();
             inputItem.EntryUri = entryUri;
-            return atp.Client.Post<NotifyOfNewEntryInput, FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryInput!, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<NotifyOfNewEntryInput, FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryInput!, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryOutput!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
@@ -44,7 +44,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
             inputItem.Subject = subject;
             inputItem.Lang = lang;
             inputItem.CreatedBy = createdBy;
-            return atp.Client.Post<CreateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationCreateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<CreateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationCreateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, inputItem, cancellationToken);
         }
 
 
@@ -60,7 +60,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
             var endpointUrl = DeleteTemplate.ToString();
             var inputItem = new DeleteTemplateInput();
             inputItem.Id = id;
-            return atp.Client.Post<DeleteTemplateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationDeleteTemplateInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteTemplateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationDeleteTemplateInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -73,7 +73,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Communication.ListTemplatesOutput?>> ListTemplatesAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ListTemplates.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Communication.ListTemplatesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationListTemplatesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Communication.ListTemplatesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationListTemplatesOutput!, cancellationToken);
         }
 
 
@@ -103,7 +103,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
             inputItem.Subject = subject;
             inputItem.UpdatedBy = updatedBy;
             inputItem.Disabled = disabled;
-            return atp.Client.Post<UpdateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationUpdateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationUpdateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
@@ -52,7 +52,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             inputItem.Subject = subject;
             inputItem.CreatedBy = createdBy;
             inputItem.SubjectBlobCids = subjectBlobCids;
-            return atp.Client.Post<EmitEventInput, FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationEmitEventInput!, atp.Options.SourceGenerationContext.ToolsOzoneModerationModEventView!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<EmitEventInput, FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationEmitEventInput!, atp.Options.SourceGenerationContext.ToolsOzoneModerationModEventView!, inputItem, cancellationToken);
         }
 
 
@@ -71,7 +71,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add("id=" + id);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationModEventViewDetail!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationModEventViewDetail!, cancellationToken);
         }
 
 
@@ -98,7 +98,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationRecordViewDetail!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationRecordViewDetail!, cancellationToken);
         }
 
 
@@ -117,7 +117,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add(string.Join("&", uris.Select(n => "uris=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetRecordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationGetRecordsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetRecordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationGetRecordsOutput!, cancellationToken);
         }
 
 
@@ -138,7 +138,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add("did=" + did);
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationRepoViewDetail!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationRepoViewDetail!, cancellationToken);
         }
 
 
@@ -157,7 +157,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add(string.Join("&", dids.Select(n => "dids=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationGetReposOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationGetReposOutput!, cancellationToken);
         }
 
 
@@ -281,7 +281,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryEventsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationQueryEventsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryEventsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationQueryEventsOutput!, cancellationToken);
         }
 
 
@@ -459,7 +459,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryStatusesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationQueryStatusesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryStatusesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationQueryStatusesOutput!, cancellationToken);
         }
 
 
@@ -493,7 +493,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.SearchReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationSearchReposOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.SearchReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationSearchReposOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServerEndpoints.g.cs
@@ -25,7 +25,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Server.GetConfigOutput?>> GetConfigAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetConfig.ToString();
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Server.GetConfigOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneServerGetConfigOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Server.GetConfigOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneServerGetConfigOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
@@ -40,7 +40,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
             var inputItem = new AddValuesInput();
             inputItem.Name = name;
             inputItem.Values = values;
-            return atp.Client.Post<AddValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetAddValuesInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<AddValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetAddValuesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -58,7 +58,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
             var endpointUrl = DeleteSet.ToString();
             var inputItem = new DeleteSetInput();
             inputItem.Name = name;
-            return atp.Client.Post<DeleteSetInput, FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetInput!, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteSetInput, FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetInput!, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetOutput!, inputItem, cancellationToken);
         }
 
 
@@ -78,7 +78,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
             var inputItem = new DeleteValuesInput();
             inputItem.Name = name;
             inputItem.Values = values;
-            return atp.Client.Post<DeleteValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteValuesInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteValuesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -111,7 +111,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Set.GetValuesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetGetValuesOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Set.GetValuesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetGetValuesOutput!, cancellationToken);
         }
 
 
@@ -157,7 +157,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Set.QuerySetsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetQuerySetsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Set.QuerySetsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetQuerySetsOutput!, cancellationToken);
         }
 
 
@@ -170,7 +170,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Set.SetView?>> UpsertSetAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpsertSet.ToString();
-            return atp.Client.Post<FishyFlip.Lexicon.Tools.Ozone.Set.SetView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetSetView!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Post<FishyFlip.Lexicon.Tools.Ozone.Set.SetView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetSetView!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
@@ -62,7 +62,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Setting.ListOptionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingListOptionsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Setting.ListOptionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingListOptionsOutput!, cancellationToken);
         }
 
 
@@ -80,7 +80,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
             var inputItem = new RemoveOptionsInput();
             inputItem.Keys = keys;
             inputItem.Scope = scope;
-            return atp.Client.Post<RemoveOptionsInput, FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<RemoveOptionsInput, FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsOutput!, inputItem, cancellationToken);
         }
 
 
@@ -104,7 +104,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
             inputItem.Value = value;
             inputItem.Description = description;
             inputItem.ManagerRole = managerRole;
-            return atp.Client.Post<UpsertOptionInput, FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpsertOptionInput, FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionOutput!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SignatureEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SignatureEndpoints.g.cs
@@ -35,7 +35,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
             queryStrings.Add(string.Join("&", dids.Select(n => "dids=" + n)));
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.FindCorrelationOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureFindCorrelationOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.FindCorrelationOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureFindCorrelationOutput!, cancellationToken);
         }
 
 
@@ -66,7 +66,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.FindRelatedAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureFindRelatedAccountsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.FindRelatedAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureFindRelatedAccountsOutput!, cancellationToken);
         }
 
 
@@ -97,7 +97,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.SearchAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureSearchAccountsOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.SearchAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureSearchAccountsOutput!, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
@@ -38,7 +38,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
             var inputItem = new AddMemberInput();
             inputItem.Did = did;
             inputItem.Role = role;
-            return atp.Client.Post<AddMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamAddMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<AddMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamAddMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, inputItem, cancellationToken);
         }
 
 
@@ -57,7 +57,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
             var endpointUrl = DeleteMember.ToString();
             var inputItem = new DeleteMemberInput();
             inputItem.Did = did;
-            return atp.Client.Post<DeleteMemberInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamDeleteMemberInput!, atp.Options.SourceGenerationContext.Success!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<DeleteMemberInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamDeleteMemberInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
         }
 
 
@@ -85,7 +85,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
             }
 
             endpointUrl += string.Join("&", queryStrings);
-            return atp.Client.Get<FishyFlip.Lexicon.Tools.Ozone.Team.ListMembersOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamListMembersOutput!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);
+            return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Team.ListMembersOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamListMembersOutput!, cancellationToken);
         }
 
 
@@ -107,7 +107,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
             inputItem.Did = did;
             inputItem.Disabled = disabled;
             inputItem.Role = role;
-            return atp.Client.Post<UpdateMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamUpdateMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
+            return atp.Post<UpdateMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamUpdateMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, inputItem, cancellationToken);
         }
 
     }

--- a/src/FishyFlip/Models/ATDid.cs
+++ b/src/FishyFlip/Models/ATDid.cs
@@ -25,6 +25,11 @@ public class ATDid : ATIdentifier
     public string Handler { get; }
 
     /// <summary>
+    /// Gets the type of DID.
+    /// </summary>
+    public string Type => this.Handler.Split(':')[1].ToLowerInvariant();
+
+    /// <summary>
     /// Create a new ATDid.
     /// </summary>
     /// <param name="uri">Uri.</param>
@@ -56,8 +61,14 @@ public class ATDid : ATIdentifier
     {
         try
         {
-            atDid = new ATDid(uri);
-            return true;
+            if (ATDid.IsValid(uri))
+            {
+                atDid = new ATDid(uri);
+                return true;
+            }
+
+            atDid = null;
+            return false;
         }
         catch (Exception)
         {

--- a/src/FishyFlip/Tools/ATProtocolExtensions.cs
+++ b/src/FishyFlip/Tools/ATProtocolExtensions.cs
@@ -167,6 +167,10 @@ public static class ATProtocolExtensions
                 {
                     host = await protocol.ResolveATDidHostAsync(did!) ?? string.Empty;
                 }
+                else if (ATHandle.TryCreate(repo, out ATHandle? handle))
+                {
+                    host = await protocol.ResolveATHandleHostAsync(handle!) ?? string.Empty;
+                }
             }
         }
 

--- a/src/FishyFlip/Tools/ATProtocolExtensions.cs
+++ b/src/FishyFlip/Tools/ATProtocolExtensions.cs
@@ -1,0 +1,193 @@
+// <copyright file="ATProtocolExtensions.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Tools;
+
+/// <summary>
+/// ATProtocol Extensions.
+/// </summary>
+public static class ATProtocolExtensions
+{
+    /// <summary>
+    /// Sends a GET request to the specified Uri as an asynchronous operation and deserializes the response.
+    /// </summary>
+    /// <typeparam name="T">The type of the response body.</typeparam>
+    /// <param name="protocol">The instance.</param>
+    /// <param name="url">The Uri the request is sent to.</param>
+    /// <param name="type">The JsonTypeInfo of the response body.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <param name="headers">Custom headers to include with the request.</param>
+    /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Http response message as the result.</returns>
+    public static async Task<Result<T?>> Get<T>(
+        this ATProtocol protocol,
+        string url,
+        JsonTypeInfo<T> type,
+        CancellationToken cancellationToken,
+        Dictionary<string, string>? headers = default)
+        {
+            var result = await protocol.ResolveHostUri(url);
+            return await protocol.Client.Get<T>(result, type, protocol.Options.JsonSerializerOptions, cancellationToken, protocol.Options.Logger, headers);
+        }
+
+    /// <summary>
+    /// Sends a GET request to the specified Uri and downloads the response as a CAR (Content-Addressable Archive) file.
+    /// </summary>
+    /// <param name="protocol">The instance.</param>
+    /// <param name="url">The Uri the request is sent to.</param>
+    /// <param name="filePath">The path where the file should be saved.</param>
+    /// <param name="fileName">The name of the file to be saved.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Success response message as the result.</returns>
+    public static async Task<Result<Success?>> DownloadCarAsync(
+        this ATProtocol protocol,
+        string url,
+        string filePath,
+        string fileName,
+        CancellationToken cancellationToken)
+        {
+            var result = await protocol.ResolveHostUri(url);
+            return await protocol.Client.DownloadCarAsync(result, filePath, fileName, protocol.Options.JsonSerializerOptions, cancellationToken, protocol.Options.Logger);
+        }
+
+    /// <summary>
+    /// Sends a GET request to the specified Uri and decodes the response as a CAR (Content-Addressable Archive).
+    /// </summary>
+    /// <param name="protocol">The instance.</param>
+    /// <param name="url">The Uri the request is sent to.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <param name="progress">The progress reporter for the decoding process. This is optional and defaults to null.</param>
+    /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Success response message as the result.</returns>
+    public static async Task<Result<Success?>> GetCarAsync(
+            this ATProtocol protocol,
+            string url,
+            CancellationToken cancellationToken,
+            OnCarDecoded? progress = null)
+        {
+            var result = await protocol.ResolveHostUri(url);
+            return await protocol.Client.GetCarAsync(result, protocol.Options.JsonSerializerOptions, cancellationToken, protocol.Options.Logger, progress);
+        }
+
+    /// <summary>
+    /// Sends a GET request to the specified Uri and retrieves the response as a Blob.
+    /// </summary>
+    /// <param name="protocol">The HttpClient instance.</param>
+    /// <param name="url">The Uri the request is sent to.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Blob response message as the result.</returns>
+    public static async Task<Result<byte[]?>> GetBlob(
+       this ATProtocol protocol,
+       string url,
+       CancellationToken cancellationToken)
+    {
+        var result = await protocol.ResolveHostUri(url);
+        return await protocol.Client.GetBlob(result, protocol.Options.JsonSerializerOptions, cancellationToken, protocol.Options.Logger);
+    }
+
+    /// <summary>
+    /// Sends a POST request with a StreamContent body to the specified Uri as an asynchronous operation.
+    /// </summary>
+    /// <typeparam name="TK">The type of the response body.</typeparam>
+    /// <param name="protocol">The HttpClient instance.</param>
+    /// <param name="url">The Uri the request is sent to.</param>
+    /// <param name="type">The JsonTypeInfo of the response body.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Http response message as the result.</returns>
+    public static async Task<Result<TK>> Post<TK>(
+        this ATProtocol protocol,
+        string url,
+        JsonTypeInfo<TK> type,
+        CancellationToken cancellationToken)
+    {
+        var result = await protocol.ResolveHostUri(url);
+        return await protocol.Client.Post<TK>(result, type, protocol.Options.JsonSerializerOptions, cancellationToken, protocol.Options.Logger);
+    }
+
+    /// <summary>
+    /// Sends a POST request with a StreamContent body to the specified Uri as an asynchronous operation.
+    /// </summary>
+    /// <typeparam name="TK">The type of the response body.</typeparam>
+    /// <param name="protocol">The HttpClient instance.</param>
+    /// <param name="url">The Uri the request is sent to.</param>
+    /// <param name="type">The JsonTypeInfo of the response body.</param>
+    /// <param name="body">The StreamContent request body.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Http response message as the result.</returns>
+    public static async Task<Result<TK>> Post<TK>(
+       this ATProtocol protocol,
+       string url,
+       JsonTypeInfo<TK> type,
+       StreamContent body,
+       CancellationToken cancellationToken)
+    {
+        var result = await protocol.ResolveHostUri(url);
+        return await protocol.Client.Post<TK>(result, type, protocol.Options.JsonSerializerOptions, body, cancellationToken, protocol.Options.Logger);
+    }
+
+    /// <summary>
+    /// Sends a POST request to the specified Uri as an asynchronous operation.
+    /// </summary>
+    /// <typeparam name="T">The type of the request body.</typeparam>
+    /// <typeparam name="TK">The type of the response body.</typeparam>
+    /// <param name="protocol">The HttpClient instance.</param>
+    /// <param name="url">The Uri the request is sent to.</param>
+    /// <param name="typeT">The JsonTypeInfo of the request body.</param>
+    /// <param name="typeTK">The JsonTypeInfo of the response body.</param>
+    /// <param name="body">The request body.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <param name="headers">Custom headers to include with the request.</param>
+    /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Http response message as the result.</returns>
+    public static async Task<Result<TK>> Post<T, TK>(
+       this ATProtocol protocol,
+       string url,
+       JsonTypeInfo<T> typeT,
+       JsonTypeInfo<TK> typeTK,
+       T body,
+       CancellationToken cancellationToken,
+       Dictionary<string, string>? headers = default)
+    {
+        var result = await protocol.ResolveHostUri(url);
+        return await protocol.Client.Post<T, TK>(result, typeT, typeTK, protocol.Options.JsonSerializerOptions, body, cancellationToken, protocol.Options.Logger, headers);
+    }
+
+    private static async Task<string> ResolveHostUri(this ATProtocol protocol, string pathAndQueryString)
+    {
+        var logger = protocol.Options.Logger;
+        string host = string.Empty;
+
+        // Find repo name in pathAndQueryString
+        if (pathAndQueryString.Contains("repo"))
+        {
+            // repo name is a query string value of "repo"
+            var repoName = pathAndQueryString.Split('&').FirstOrDefault(x => x.Contains("repo"));
+            if (!string.IsNullOrEmpty(repoName))
+            {
+                var repo = repoName.Split('=')[1];
+                if (ATDid.TryCreate(repo, out ATDid? did))
+                {
+                    host = await protocol.ResolveATDidHostAsync(did!) ?? string.Empty;
+                }
+            }
+        }
+
+        if (string.IsNullOrEmpty(host))
+        {
+            host = protocol.Options.Url.ToString();
+            logger?.LogDebug($"Host was empty, using default host {host}");
+        }
+
+        if (host.EndsWith("/") && pathAndQueryString.StartsWith("/"))
+        {
+            host = host[0..^1];
+        }
+        else if (!host.EndsWith("/") && !pathAndQueryString.StartsWith("/"))
+        {
+            host += "/";
+        }
+
+        var result = $"{host}{pathAndQueryString}";
+        logger?.LogDebug($"Resolved Host Uri: {result}");
+        return result;
+    }
+}
+

--- a/src/FishyFlip/Tools/ATProtocolExtensions.cs
+++ b/src/FishyFlip/Tools/ATProtocolExtensions.cs
@@ -159,7 +159,7 @@ public static class ATProtocolExtensions
         if (pathAndQueryString.Contains("repo"))
         {
             // repo name is a query string value of "repo"
-            var repoName = pathAndQueryString.Split('&').FirstOrDefault(x => x.Contains("repo"));
+            var repoName = pathAndQueryString.Split('&').FirstOrDefault(x => x.Contains("repo="));
             if (!string.IsNullOrEmpty(repoName))
             {
                 var repo = repoName.Split('=')[1];

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -1117,12 +1117,12 @@ public partial class AppCommands
                     if (inputProperties.Count <= 2)
                     {
                         sb.AppendLine(
-                            $"            return atp.Client.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);");
+                            $"            return atp.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, cancellationToken);");
                     }
                     else if (inputProperties[1].Contains("StreamContent"))
                     {
                         sb.AppendLine(
-                            $"            return atp.Client.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, atp.Options.JsonSerializerOptions, {inputProperties[1].Split(" ").Last()}, cancellationToken, atp.Options.Logger);");
+                            $"            return atp.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, {inputProperties[1].Split(" ").Last()}, cancellationToken);");
                     }
                     else
                     {
@@ -1136,9 +1136,8 @@ public partial class AppCommands
                                 $"            inputItem.{prop.Replace("@", string.Empty).ToPascalCase()} = {prop};");
                         }
 
-                        // return atp.Client.Post<FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountInput?, FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountOutput!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);
                         sb.AppendLine(
-                            $"            return atp.Client.Post<{item.ClassName}Input, {outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{inputSourceContext}!, atp.Options.SourceGenerationContext.{sourceContext}!, atp.Options.JsonSerializerOptions, inputItem, cancellationToken, atp.Options.Logger);");
+                            $"            return atp.Post<{item.ClassName}Input, {outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{inputSourceContext}!, atp.Options.SourceGenerationContext.{sourceContext}!, inputItem, cancellationToken);");
                     }
 
                     break;
@@ -1199,17 +1198,17 @@ public partial class AppCommands
                     if (inputProperties.Any(n => n.Contains("OnCarDecoded")))
                     {
                         sb.AppendLine(
-                            $"            return atp.Client.GetCarAsync(endpointUrl, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger, onDecoded);");
+                            $"            return atp.GetCarAsync(endpointUrl, cancellationToken, onDecoded);");
                     }
                     else if (outputProperty == "byte[]")
                     {
                         sb.AppendLine(
-                            $"            return atp.Client.GetBlob(endpointUrl, SourceGenerationContext.Default.Options, cancellationToken, atp.Options.Logger);");
+                            $"            return atp.GetBlob(endpointUrl, cancellationToken);");
                     }
                     else
                     {
                         sb.AppendLine(
-                            $"            return atp.Client.Get<{outputProperty}>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, atp.Options.JsonSerializerOptions, cancellationToken, atp.Options.Logger);");
+                            $"            return atp.Get<{outputProperty}>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, cancellationToken);");
                     }
 
                     break;


### PR DESCRIPTION
The default behavior for handling URI resolution was wrong. The process I was using was:

- Use `bsky.social` as the default for unauthenticated calls (Or whatever the Instance URI was set to in the options)
- Switch to the users PDS for authenticated calls

This is wrong and would result in 404s when trying to resolve for records outside of bsky.social or the users logged in PDS: The correct behavior, as I understand it, is to resolve the users PDS based on the DID values. If it's a `did:plc`, it can be resolved from a service like `plc.directory` and if it's `did:web` it can be gotten from the web address embedded in the DID.

This PR adds that functionality, the new behavior is:

- Don't automatically set a base URI for all ATProtocol calls
- Any call that is made to another users repo (E.g, `repo` lexicon requests) should resolve to get that users PDS first. If found, cache the PDS value so it doesn't need to resolve again.
- If using a handle instead of a DID, continue to resolve it against `bsky.social` or the Instance URI set in the options. 
- Authenticated calls are made against the logged in users PDS