### PR TITLE
Fix Facet Parsing

### DIFF
--- a/src/FishyFlip/Models/Facet.cs
+++ b/src/FishyFlip/Models/Facet.cs
@@ -74,7 +74,7 @@ public partial class Facet
     public static Facet[] ForUris(string post)
     {
         var facets = new List<Facet>();
-        var matches = Regex.Matches(post, @"(https?://[^\s]+)").DistinctBy(n => n.Value);
+        var matches = Regex.Matches(post, @"(https?://[^\s]+)");
         var postBytes = Encoding.UTF8.GetBytes(post);
         var startIndex = 0;
         foreach (Match match in matches)
@@ -98,7 +98,7 @@ public partial class Facet
     public static Facet[] ForUris(string post, string baseText, string uri)
     {
         var facets = new List<Facet>();
-        var matches = Regex.Matches(post, baseText).DistinctBy(n => n.Value);
+        var matches = Regex.Matches(post, baseText);
         var postBytes = Encoding.UTF8.GetBytes(post);
         var startIndex = 0;
         foreach (Match match in matches)

--- a/src/FishyFlip/Models/Facet.cs
+++ b/src/FishyFlip/Models/Facet.cs
@@ -74,13 +74,15 @@ public partial class Facet
     public static Facet[] ForUris(string post)
     {
         var facets = new List<Facet>();
-        var matches = Regex.Matches(post, @"(https?://[^\s]+)");
+        var matches = Regex.Matches(post, @"(https?://[^\s]+)").DistinctBy(n => n.Value);
+        var postBytes = Encoding.UTF8.GetBytes(post);
+        var startIndex = 0;
         foreach (Match match in matches)
         {
-            var start = match.Index;
-            var end = match.Index + match.Length;
-            var uri = match.Value;
-            facets.Add(CreateFacetLink(start, end, uri));
+            var matchBytes = Encoding.UTF8.GetBytes(match.Value);
+            var position = FindPattern(postBytes, matchBytes, startIndex);
+            startIndex = position.End;
+            facets.Add(CreateFacetLink(position.Start, position.End, match.Value));
         }
 
         return facets.ToArray();
@@ -96,12 +98,15 @@ public partial class Facet
     public static Facet[] ForUris(string post, string baseText, string uri)
     {
         var facets = new List<Facet>();
-        var matches = Regex.Matches(post, baseText);
+        var matches = Regex.Matches(post, baseText).DistinctBy(n => n.Value);
+        var postBytes = Encoding.UTF8.GetBytes(post);
+        var startIndex = 0;
         foreach (Match match in matches)
         {
-            var start = match.Index;
-            var end = match.Index + match.Length;
-            facets.Add(CreateFacetLink(start, end, uri));
+            var matchBytes = Encoding.UTF8.GetBytes(match.Value);
+            var position = FindPattern(postBytes, matchBytes, startIndex);
+            startIndex = position.End;
+            facets.Add(CreateFacetLink(position.Start, position.End, uri));
         }
 
         return facets.ToArray();
@@ -118,10 +123,13 @@ public partial class Facet
 
         // Match all hashtags in the post that are not part of a URL.
         var matches = Regex.Matches(post, @"(?<![@\w/])#(?!\s)[\w\u0080-\uFFFF]+");
+        var postBytes = Encoding.UTF8.GetBytes(post);
+        var startIndex = 0;
         foreach (Match match in matches)
         {
-            var start = match.Index;
-            var end = match.Index + match.Length;
+            var matchBytes = Encoding.UTF8.GetBytes(match.Value);
+            var position = FindPattern(postBytes, matchBytes, startIndex);
+
             var hashtag = match.Value;
 
             if (hashtag.StartsWith("#"))
@@ -129,12 +137,8 @@ public partial class Facet
                 hashtag = hashtag.Substring(1);
             }
 
-            if (string.IsNullOrEmpty(hashtag))
-            {
-                continue;
-            }
-
-            facets.Add(CreateFacetHashtag(start, end, hashtag));
+            facets.Add(CreateFacetHashtag(position.Start, position.End, hashtag));
+            startIndex = position.End;
         }
 
         return facets.ToArray();
@@ -152,10 +156,13 @@ public partial class Facet
 
         // Match all mentions in the post that are not part of a URL.
         var matches = Regex.Matches(post, @"@(?!http)[a-zA-Z0-9][-a-zA-Z0-9_.]{1,}");
+        var postBytes = Encoding.UTF8.GetBytes(post);
+        var startIndex = 0;
         foreach (Match match in matches)
         {
-            var start = match.Index;
-            var end = match.Index + match.Length;
+            var matchBytes = Encoding.UTF8.GetBytes(match.Value);
+            var position = FindPattern(postBytes, matchBytes, startIndex);
+
             var mention = match.Value;
             if (mention.StartsWith("@"))
             {
@@ -170,8 +177,10 @@ public partial class Facet
             var actor = actors.FirstOrDefault(n => n.Handle.ToString() == mention);
             if (actor?.Did is not null)
             {
-                facets.Add(CreateFacetMention(start, end, actor.Did));
+                facets.Add(CreateFacetMention(position.Start, position.End, actor.Did));
             }
+
+            startIndex = position.End;
         }
 
         return facets.ToArray();
@@ -239,4 +248,55 @@ public partial class Facet
     /// <returns>Array of Facets.</returns>
     public static Facet[] ForMentions(string post, FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewBasic actor)
         => ForMentions(post, new FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewBasic[] { actor });
+
+    /// <summary>
+    /// Parses a post and returns an array of facets.
+    /// </summary>
+    /// <param name="post">The post text.</param>
+    /// <param name="actors">Optional list of Actor DID values, used for creating Mention Facets.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] Parse(string post, FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewBasic[]? actors = null)
+    {
+        var uriFacets = ForUris(post);
+        var hashtagFacets = ForHashtags(post);
+        var mentionFacets = ForMentions(post, actors ?? Array.Empty<Actor.ProfileViewBasic>());
+        return uriFacets.Concat(hashtagFacets).Concat(mentionFacets).ToArray();
+    }
+
+    /// <summary>
+    /// Parses a post and returns an array of facets.
+    /// </summary>
+    /// <param name="post">The post text.</param>
+    /// <param name="actors">Optional list of Actor DID values, used for creating Mention Facets.</param>
+    /// <returns>Array of Facets.</returns>
+    public static Facet[] Parse(string post, FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed[]? actors = null)
+    {
+        var uriFacets = ForUris(post);
+        var hashtagFacets = ForHashtags(post);
+        var mentionFacets = ForMentions(post, actors ?? Array.Empty<Actor.ProfileViewDetailed>());
+        return uriFacets.Concat(hashtagFacets).Concat(mentionFacets).ToArray();
+    }
+
+    private static (int Start, int End) FindPattern(byte[] source, byte[] pattern, int startIndex = 0)
+    {
+        return FindPattern(source.AsSpan(), pattern.AsSpan(), startIndex);
+    }
+
+    private static (int Start, int End) FindPattern(ReadOnlySpan<byte> source, ReadOnlySpan<byte> pattern, int startIndex = 0)
+    {
+        if (pattern.IsEmpty || pattern.Length > source.Length)
+        {
+            return (0, 0);
+        }
+
+        for (int i = startIndex; i <= source.Length - pattern.Length; i++)
+        {
+            if (source.Slice(i, pattern.Length).SequenceEqual(pattern))
+            {
+                return (i, i + pattern.Length);
+            }
+        }
+
+        return (0, 0);
+    }
 }


### PR DESCRIPTION
In the documentation, I had wrote that you need to get the byte slice to create a facet. For example:

```csharp
// To insert a link, we need to find the start and end of the link text.
// This is done as a "ByteSlice."
int promptStart = prompt.IndexOf("Link Goes Here!", StringComparison.InvariantCulture);
int promptEnd = promptStart + Encoding.Default.GetBytes("Link Goes Here!").Length;
var index = new FacetIndex(promptStart, promptEnd);
var link = FacetFeature.CreateLink("https://drasticactions.dev");
var facet = new Facet(index, link);
```

This is "kinda" right (You do need to get the bytes from UTF8, not rely on the default from .NET, and the start index may not represent the actual place in the byte array), but not only is this not totally correct, the helps I wrote to make them were not using this. They were using Length from the matched Regex. This would break with Unicode/non-ASCII characters.

This should fix it by using spans to pattern match.

To use the new helpers, you can use `Facet.Parse` for a complete string, or `Facet.ForMentions`, `Facet.ForHashtags`, `Facet.ForMentions` for the individual facets.

