### PR TITLE
Update PasswordAuth with AuthenticateWithPasswordResultAsync

### DIFF
--- a/.github/workflows/bskycli.yml
+++ b/.github/workflows/bskycli.yml
@@ -23,7 +23,7 @@ jobs:
         - name: Install GitVersion
           uses: gittools/actions/gitversion/setup@v3.0.3
           with:
-            versionSpec: '6.x'
+            versionSpec: '6.0.5'
 
         - name: Run make linux-x64
           run: make bskycli_linux
@@ -53,7 +53,7 @@ jobs:
         - name: Install GitVersion
           uses: gittools/actions/gitversion/setup@v3.0.3
           with:
-            versionSpec: '6.x'
+            versionSpec: '6.0.5'
 
         - name: Run make osx
           run: make bskycli_macos
@@ -89,7 +89,7 @@ jobs:
           - name: Install GitVersion
             uses: gittools/actions/gitversion/setup@v3.0.3
             with:
-              versionSpec: '6.x'
+              versionSpec: '6.0.5'
 
           - name: Run powershell script
             run: |

--- a/apps/bskycli/Program.cs
+++ b/apps/bskycli/Program.cs
@@ -576,7 +576,7 @@ public class AppCommands
             return false;
         }
 
-        var result = await atProtocol.AuthenticateWithPasswordAsync(username, password);
+        var (result, error) = await atProtocol.AuthenticateWithPasswordResultAsync(username, password);
         if (result is null)
         {
             consoleLog.LogError($"Failed to authenticate as {username}.");

--- a/samples/PasswordAuth/Program.cs
+++ b/samples/PasswordAuth/Program.cs
@@ -31,7 +31,7 @@ public class AppCommands
             .WithLogger(new DebugLoggerProvider().CreateLogger("FishyFlip"))
             .Build();
 
-        var session = await protocol.AuthenticateWithPasswordAsync(identifier, password, cancellationToken);
+        var (session, error) = await protocol.AuthenticateWithPasswordResultAsync(identifier, password, cancellationToken);
         if (session is null)
         {
             Console.WriteLine("Failed to authenticate.");

--- a/src/FishyFlip.Auth.Tests/AuthorizedTests.cs
+++ b/src/FishyFlip.Auth.Tests/AuthorizedTests.cs
@@ -36,7 +36,7 @@ public class AuthorizedTests
             .WithInstanceUrl(new Uri(instance))
             .WithLogger(debugLog.CreateLogger("FishyFlipTests"));
         AuthorizedTests.proto = atProtocolBuilder.Build();
-        AuthorizedTests.proto!.AuthenticateWithPasswordAsync(handle, password).Wait();
+        AuthorizedTests.proto!.AuthenticateWithPasswordResultAsync(handle, password).Wait();
     }
 
     /// <summary>

--- a/src/FishyFlip/ATProtocol.cs
+++ b/src/FishyFlip/ATProtocol.cs
@@ -116,12 +116,27 @@ public sealed partial class ATProtocol : IDisposable
     /// <param name="password">The password of the user.</param>
     /// <param name="cancellationToken">Optional. A CancellationToken that can be used to cancel the operation.</param>
     /// <returns>A Task that represents the asynchronous operation. The task result contains a Result object with the session details, or null if the session could not be created.</returns>
-    public async Task<Session?> AuthenticateWithPasswordAsync(string identifier, string password, CancellationToken cancellationToken = default)
+    public async Task<Result<Session?>> AuthenticateWithPasswordResultAsync(string identifier, string password, CancellationToken cancellationToken = default)
     {
         var passwordSessionManager = new PasswordSessionManager(this);
         this.SessionManager = passwordSessionManager;
 
         return await passwordSessionManager.CreateSessionAsync(identifier, password, cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously creates a new session manager using a password.
+    /// </summary>
+    /// <param name="identifier">The identifier of the user.</param>
+    /// <param name="password">The password of the user.</param>
+    /// <param name="cancellationToken">Optional. A CancellationToken that can be used to cancel the operation.</param>
+    /// <returns>A Task that represents the asynchronous operation. The task result contains a Result object with the session details, or null if the session could not be created.</returns>
+    [Obsolete("Use AuthenticateWithPasswordResultAsync instead.")]
+    public async Task<Session?> AuthenticateWithPasswordAsync(string identifier, string password, CancellationToken cancellationToken = default)
+    {
+        // The error is logged in the AuthenticateWithPasswordResultAsync method.
+        var (result, _) = await this.AuthenticateWithPasswordResultAsync(identifier, password, cancellationToken);
+        return result;
     }
 
     /// <summary>

--- a/src/FishyFlip/Tools/ATProtocolUnknownError.cs
+++ b/src/FishyFlip/Tools/ATProtocolUnknownError.cs
@@ -1,0 +1,21 @@
+// <copyright file="ATProtocolUnknownError.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Tools;
+
+/// <summary>
+/// AT Network ATError Exception.
+/// Thrown if given a failed result from ATProtocol.
+/// </summary>
+public class ATProtocolUnknownError : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ATProtocolUnknownError"/> class.
+    /// </summary>
+    /// <param name="atError">ATError message.</param>
+    public ATProtocolUnknownError(string atError)
+            : base(atError)
+    {
+    }
+}

--- a/website/docs/logging-in.md
+++ b/website/docs/logging-in.md
@@ -2,14 +2,14 @@
 
 - There are two methods for logging in: OAuth and App Passwords. App Passwords were the original method for authentication, with OAuth being its replacement. However, the ATProtocol OAuth implementation is still being worked on and not totally final. If building a new application with authentication in mind, you may wish to design with OAuth for the future, but use app passwords today.
 
-- To log in with an App Password, you can call `AuthenticateWithPasswordAsync`
+- To log in with an App Password, you can call `AuthenticateWithPasswordResultAsync`
 
 ```csharp
 var atProtocol = new ATProtocolBuilder()
             .WithLogger(new DebugLoggerProvider().CreateLogger("FishyFlip"))
             .Build();
 
-var session = await atProtocol.AuthenticateWithPasswordAsync(identifier, password, cancellationToken);
+var (session, error) = await atProtocol.AuthenticateWithPasswordResultAsync(identifier, password, cancellationToken);
 if (session is null)
 {
     Console.WriteLine("Failed to authenticate.");


### PR DESCRIPTION
Instead of only returning the null `Session` with `AuthenticateWithPasswordAsync`, it should return a `Result<Session?>` instead so you can get access to the error object directly. Before, it was only being surfaced inside of the logger, which may not have been obvious enough a location for it. This would also map to the rest of the APIs when directly talking to the lexicon, so this makes sense to do here.

I obsoleted the original `AuthenticateWithPasswordAsync` to make it clear you should use `AuthenticateWithPasswordResultAsync` instead to get the error object.