### PR TITLE
Use public.api.bsky.app for unauthed sessions by default

### DIFF
--- a/apps/bskycli/Program.cs
+++ b/apps/bskycli/Program.cs
@@ -45,7 +45,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("post video")]
-    public async Task CreatePostWithVideoAsync([Argument] string videoPath, string username, string password, string? embedRecord = default, string? embedRecordCid = default, string? alt = default, string[]? vttFiles = default, string[]? vttFileLanaguages = default, string? post = default, string[]? languages = default, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task CreatePostWithVideoAsync([Argument] string videoPath, string username, string password, string? embedRecord = default, string? embedRecordCid = default, string? alt = default, string[]? vttFiles = default, string[]? vttFileLanaguages = default, string? post = default, string[]? languages = default, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
         ATUri? atUri = null;
@@ -165,7 +165,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("post image")]
-    public async Task CreatePostWithImagesAsync([Argument] string[] imagePaths, string username, string password, string? embedRecord = default, string? embedRecordCid = default, string[]? imageAlts = default, string? post = default, string[]? languages = default, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task CreatePostWithImagesAsync([Argument] string[] imagePaths, string username, string password, string? embedRecord = default, string? embedRecordCid = default, string[]? imageAlts = default, string? post = default, string[]? languages = default, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
 
@@ -264,7 +264,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("post")]
-    public async Task CreatePostAsync([Argument] string post, string username, string password, string? embedRecord = default, string? embedRecordCid = default, string? embeddedUrl = default, string[]? languages = default, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task CreatePostAsync([Argument] string post, string username, string password, string? embedRecord = default, string? embedRecordCid = default, string? embeddedUrl = default, string[]? languages = default, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
 
@@ -335,7 +335,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("did-doc")]
-    public async Task GetDidDocAsync([Argument] string did, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task GetDidDocAsync([Argument] string did, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
         var atProtocol = this.GenerateProtocol(instanceUrl, consoleLog);
@@ -364,7 +364,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("resolve-handle")]
-    public async Task ResolveHandleAsync([Argument] string handle, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task ResolveHandleAsync([Argument] string handle, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
         var atProtocol = this.GenerateProtocol(instanceUrl, consoleLog);
@@ -395,7 +395,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("download")]
-    public async Task DownloadBlobAsync([Argument] string atDid, [Argument] string cid, string? outputName = default, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task DownloadBlobAsync([Argument] string atDid, [Argument] string cid, string? outputName = default, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
         var atProtocol = this.GenerateProtocol(instanceUrl, consoleLog);
@@ -437,7 +437,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("atfile download")]
-    public async Task DownloadATFileAsync([Argument] string atDidString, [Argument] string rkey, string? outputName = default, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task DownloadATFileAsync([Argument] string atDidString, [Argument] string rkey, string? outputName = default, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
         var atProtocol = this.GenerateProtocol(instanceUrl, consoleLog);
@@ -532,7 +532,7 @@ public class AppCommands
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Task.</returns>
     [Command("atfile list")]
-    public async Task ListATFilesAsync([Argument] string atDid, string instanceUrl = "https://bsky.social", bool verbose = false, CancellationToken cancellationToken = default)
+    public async Task ListATFilesAsync([Argument] string atDid, string instanceUrl = "https://public.api.bsky.app", bool verbose = false, CancellationToken cancellationToken = default)
     {
         var consoleLog = new ConsoleLog(verbose);
         var atProtocol = this.GenerateProtocol(instanceUrl, consoleLog);

--- a/src/FishyFlip.Auth.Tests/AuthorizedTests.cs
+++ b/src/FishyFlip.Auth.Tests/AuthorizedTests.cs
@@ -29,11 +29,9 @@ public class AuthorizedTests
     {
         string handle = (string?)context.Properties["BLUESKY_TEST_HANDLE"] ?? throw new ArgumentNullException();
         string password = (string?)context.Properties["BLUESKY_TEST_PASSWORD"] ?? throw new ArgumentNullException();
-        string instance = "https://bsky.social";
         var debugLog = new DebugLoggerProvider();
         var atProtocolBuilder = new ATProtocolBuilder()
             .EnableAutoRenewSession(false)
-            .WithInstanceUrl(new Uri(instance))
             .WithLogger(debugLog.CreateLogger("FishyFlipTests"));
         AuthorizedTests.proto = atProtocolBuilder.Build();
         AuthorizedTests.proto!.AuthenticateWithPasswordResultAsync(handle, password).Wait();

--- a/src/FishyFlip.Tests/AnonymousTests.cs
+++ b/src/FishyFlip.Tests/AnonymousTests.cs
@@ -26,11 +26,9 @@ public class AnonymousTests
     [ClassInitialize]
     public static void ClassInitialize(TestContext context)
     {
-        string instance = "https://bsky.social";
         var debugLog = new DebugLoggerProvider();
         var atProtocolBuilder = new ATProtocolBuilder()
             .EnableAutoRenewSession(false)
-            .WithInstanceUrl(new Uri(instance))
             .WithLogger(debugLog.CreateLogger("FishyFlipTests"));
         AnonymousTests.proto = atProtocolBuilder.Build();
     }

--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -19,7 +19,7 @@ public class ATProtocolOptions
     /// <param name="customAtRecordConverters">Customer JSON Converters for ATRecord.</param>
     public ATProtocolOptions()
     {
-        this.Url = new Uri(Constants.Urls.ATProtoServer.SocialApi);
+        this.Url = new Uri(Constants.Urls.ATProtoServer.PublicApi);
         this.JsonSerializerOptions = new JsonSerializerOptions()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/src/FishyFlip/Tools/DidDocExtensions.cs
+++ b/src/FishyFlip/Tools/DidDocExtensions.cs
@@ -1,0 +1,33 @@
+// <copyright file="DidDocExtensions.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Tools;
+
+/// <summary>
+/// DidDoc extensions.
+/// </summary>
+public static class DidDocExtensions
+{
+    /// <summary>
+    /// Gets the service endpoint URL.
+    /// </summary>
+    /// <param name="didDoc">The DidDoc.</param>
+    /// <returns>Uri.</returns>
+    public static Uri? GetServiceEndpointUrl(this DidDoc didDoc)
+    {
+        var serviceUrl = didDoc.Service?.FirstOrDefault()?.ServiceEndpoint;
+        if (serviceUrl is null)
+        {
+            return null;
+        }
+
+        var result = Uri.TryCreate(serviceUrl, UriKind.Absolute, out Uri? uriResult);
+        if (!result)
+        {
+            return null;
+        }
+
+        return uriResult;
+    }
+}


### PR DESCRIPTION
This makes a minor-ish breaking change to the default Instance URL that's created. Originally, I was using "https://bsky.social" as the default, which does not work well for unauthenticated endpoints when compared to the public API. But, for 99% of user sessions when you need to authenticate, you want that. And generally, when you're logged in, you want to use your PDS.

I tried to get the logic right by:

- Switching the default Instance URL to the public API ("https://public.api.bsky.app") by default.
- If you try logging with this set as the instance URL (and you didn't set one yourself for the users PDS), it will switch back to bsky.social for the CreateSession call, which will then set the correct PDS from then on.
- If you had set the Instance Uri in the builder, nothing changes, it will default to that.