### PR TITLE
Add PostRecord helper property for PostView

### DIFF
--- a/src/FishyFlip/Models/PostView.cs
+++ b/src/FishyFlip/Models/PostView.cs
@@ -1,0 +1,19 @@
+// <copyright file="PostView.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Lexicon.App.Bsky.Feed;
+
+/// <summary>
+/// Post View.
+/// </summary>
+public partial class PostView : ATObject
+{
+    /// <summary>
+    /// Gets the post record.
+    /// This is a helper property for getting the Post record,
+    /// which is stored in the Record property and listed as "unknown" in the Bluesky lexicon.
+    /// </summary>
+    [JsonIgnore]
+    public Post? PostRecord => this.Record as Post;
+}


### PR DESCRIPTION
`PostView` contains a `Record`, which 99% of the time is a `Post` ATObject. However, in the Bluesky Lexicon, it's listed as "unknown." This is not [ideal](https://github.com/bluesky-social/atproto/issues/999). Most clients end up using a hard cast to `Post`. I don't want to do that at a library level, since this is trying to map 1:1 with the lexicon, but it is very annoying and not obvious to those looking why this is an ATObject.

To make it easier to get to the Post Text (AKA What you probably want) I am adding a helper `PostRecord` cast to `PostView` that will give a hard cast on `Record` to `Post`, if it is a post.