### PR TITLE
Resolve Users Host PDS before authentication

### DIFF
--- a/src/FishyFlip/Tools/ATProtocolExtensions.cs
+++ b/src/FishyFlip/Tools/ATProtocolExtensions.cs
@@ -153,7 +153,7 @@ public static class ATProtocolExtensions
     private static async Task<string> ResolveHostUri(this ATProtocol protocol, string pathAndQueryString)
     {
         var logger = protocol.Options.Logger;
-        string host = string.Empty;
+        string? host = null;
 
         // Find repo name in pathAndQueryString
         if (pathAndQueryString.Contains("repo"))
@@ -165,11 +165,11 @@ public static class ATProtocolExtensions
                 var repo = repoName.Split('=')[1];
                 if (ATDid.TryCreate(repo, out ATDid? did))
                 {
-                    host = await protocol.ResolveATDidHostAsync(did!) ?? string.Empty;
+                    (host, _) = await protocol.ResolveATDidHostAsync(did!);
                 }
                 else if (ATHandle.TryCreate(repo, out ATHandle? handle))
                 {
-                    host = await protocol.ResolveATHandleHostAsync(handle!) ?? string.Empty;
+                    (host, _) = await protocol.ResolveATHandleHostAsync(handle!);
                 }
             }
         }
@@ -182,7 +182,7 @@ public static class ATProtocolExtensions
                 var did = didName.Split('=')[1];
                 if (ATDid.TryCreate(did, out ATDid? atdid))
                 {
-                    host = await protocol.ResolveATDidHostAsync(atdid!) ?? string.Empty;
+                    (host, _) = await protocol.ResolveATDidHostAsync(atdid!);
                 }
             }
         }
@@ -214,7 +214,7 @@ public static class ATProtocolExtensions
             throw new InvalidOperationException("Host is required.");
         }
 
-        if (host.EndsWith("/") && pathAndQueryString.StartsWith("/"))
+        if (host!.EndsWith("/") && pathAndQueryString.StartsWith("/"))
         {
             host = host[0..^1];
         }

--- a/website/docs/logging-in.md
+++ b/website/docs/logging-in.md
@@ -23,6 +23,8 @@ Console.WriteLine($"Session Handle: {session.Handle}");
 Console.WriteLine($"Session Token: {session.AccessJwt}");
 ```
 
+If you don't override the Instance URL in `ATProtocolBuilder.WithInstanceUrl` the users PDS Host will be resolved before the authentication attempt is made and will be used for authentication and future requests. If you have set it, the authentication request will be resolved against that endpoint. 
+
 - OAuth authentication is more complex. There is a full example showing a [local user authentication session](https://github.com/drasticactions/BSkyOAuthTokenGenerator/tree/main/src/BSkyOAuthTokenGenerator) but in short, you must:
   - Starting the session with `atProtocol.GenerateOAuth2AuthenticationUrlAsync`
   - Sending the user to a web browser to log in


### PR DESCRIPTION
If you have not changed the Instance URL in the `ATProtocolBuilder` (or have set it to use the Bluesky Public API, as is the default), `AtProtocol.AuthenticateWithPasswordResultAsync` will now resolve the host PDS address for you, instead of falling back to `bsky.social.` 

If you have changed the instance URL to another endpoint, `AuthenticateWithPasswordResultAsync` will respect it and continue to use that endpoint for authentication.