### PR TITLE
Add DidDoc helpers

### DIFF
--- a/src/FishyFlip/ATProtocol.cs
+++ b/src/FishyFlip/ATProtocol.cs
@@ -246,7 +246,7 @@ public sealed partial class ATProtocol : IDisposable
 
         if (this.IsAuthenticated && this.Session?.Handle.ToString() == handle.ToString())
         {
-            host = this.Session?.DidDoc?.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
+            host = this.Session?.DidDoc?.GetPDSEndpointUrl(this.options.Logger)?.ToString();
             if (!string.IsNullOrEmpty(host))
             {
                 this.options.DidCache[handle.ToString()] = host!;
@@ -386,8 +386,7 @@ public sealed partial class ATProtocol : IDisposable
         string? host = null;
         if (this.IsAuthenticated && this.Session?.Did.ToString() == did.ToString())
         {
-            host = this.Session?.DidDoc?.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)
-                ?.ServiceEndpoint;
+            host = this.Session?.DidDoc?.GetPDSEndpointUrl(this.options.Logger)?.ToString();
             if (!string.IsNullOrEmpty(host))
             {
                 this.options.DidCache[did.ToString()] = host!;
@@ -402,8 +401,7 @@ public sealed partial class ATProtocol : IDisposable
         var (resolveHandle, error) = await this.PlcDirectory.GetDidDocAsync(did!, token ?? CancellationToken.None);
         if (resolveHandle is not null)
         {
-            host = resolveHandle.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)
-                ?.ServiceEndpoint;
+            host = resolveHandle.GetPDSEndpointUrl(this.options.Logger)?.ToString();
             if (string.IsNullOrEmpty(host))
             {
                 this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing Service Handle.");
@@ -435,8 +433,7 @@ public sealed partial class ATProtocol : IDisposable
                 var didDoc = JsonSerializer.Deserialize<DidDoc>(await result.Content.ReadAsStringAsync(), this.options.SourceGenerationContext.DidDoc);
                 if (didDoc is not null)
                 {
-                    host = didDoc.Service.FirstOrDefault(n => n.Type == Constants.AtprotoPersonalDataServer)
-                        ?.ServiceEndpoint;
+                    host = didDoc.GetPDSEndpointUrl(this.options.Logger)?.ToString();
                     if (string.IsNullOrEmpty(host))
                     {
                         this.options.Logger?.LogError($"Failed to resolve DID: {did}, missing Service Handle.");

--- a/src/FishyFlip/Constants.cs
+++ b/src/FishyFlip/Constants.cs
@@ -9,6 +9,7 @@ public static class Constants
 {
     internal const string DidJson = ".well-known/did.json";
     internal const string AtprotoPersonalDataServer = "AtprotoPersonalDataServer";
+    internal const string AtprotoPersonalDataServerId = "#atproto_pds";
     internal const string BlueskyApiClient = "FishyFlip";
     internal const string ContentMediaType = "application/json";
     internal const string AcceptedMediaType = "application/json";

--- a/src/FishyFlip/Tools/ATProtocolExtensions.cs
+++ b/src/FishyFlip/Tools/ATProtocolExtensions.cs
@@ -191,7 +191,7 @@ public static class ATProtocolExtensions
         {
             if (protocol.IsAuthenticated)
             {
-                host = protocol.SessionManager.Session?.DidDoc?.GetServiceEndpointUrl()?.ToString() ?? throw new InvalidOperationException("Session did doc is required.");
+                host = protocol.SessionManager.Session?.DidDoc?.GetPDSEndpointUrl()?.ToString() ?? throw new InvalidOperationException("Session did doc is required.");
                 logger?.LogDebug($"Using PDS host {host}");
             }
             else

--- a/src/FishyFlip/Tools/DidDocExtensions.cs
+++ b/src/FishyFlip/Tools/DidDocExtensions.cs
@@ -13,18 +13,58 @@ public static class DidDocExtensions
     /// Gets the service endpoint URL.
     /// </summary>
     /// <param name="didDoc">The DidDoc.</param>
+    /// <param name="serviceType">The service type.</param>
+    /// <param name="logger">The logger.</param>
     /// <returns>Uri.</returns>
-    public static Uri? GetServiceEndpointUrl(this DidDoc didDoc)
+    public static Uri? GetServiceEndpointUrl(this DidDoc didDoc, string serviceType, ILogger? logger = null)
     {
-        var serviceUrl = didDoc.Service?.FirstOrDefault()?.ServiceEndpoint;
+        var serviceUrl = didDoc.Service?.FirstOrDefault(s => s.Id == serviceType)?.ServiceEndpoint;
         if (serviceUrl is null)
         {
+            serviceUrl = didDoc.Service?.FirstOrDefault(s => s.Type == serviceType)?.ServiceEndpoint;
+        }
+
+        if (serviceUrl is null)
+        {
+            logger?.LogWarning($"DidDoc does not contain an endpoint for {serviceType}");
             return null;
         }
 
         var result = Uri.TryCreate(serviceUrl, UriKind.Absolute, out Uri? uriResult);
         if (!result)
         {
+            logger?.LogWarning("DidDoc contains an invalid service endpoint.");
+            return null;
+        }
+
+        return uriResult;
+    }
+
+    /// <summary>
+    /// Gets the PDS endpoint URL.
+    /// </summary>
+    /// <param name="didDoc">The DidDoc.</param>
+    /// <param name="logger">The logger.</param>
+    /// <returns>Uri.</returns>
+    public static Uri? GetPDSEndpointUrl(this DidDoc didDoc, ILogger? logger = null)
+    {
+        var serviceUrl = didDoc.Service?.FirstOrDefault(s => s.Id == Constants.AtprotoPersonalDataServerId)?.ServiceEndpoint;
+        if (serviceUrl is null)
+        {
+            logger?.LogWarning($"DidDoc does not contain a PDS endpoint with {Constants.AtprotoPersonalDataServerId}. Falling back to AtprotoPersonalDataServer.");
+            serviceUrl = didDoc.Service?.FirstOrDefault(s => s.Type == Constants.AtprotoPersonalDataServer)?.ServiceEndpoint;
+        }
+
+        if (serviceUrl is null)
+        {
+            logger?.LogWarning("DidDoc does not contain a PDS endpoint.");
+            return null;
+        }
+
+        var result = Uri.TryCreate(serviceUrl, UriKind.Absolute, out Uri? uriResult);
+        if (!result)
+        {
+            logger?.LogWarning("DidDoc contains an invalid PDS endpoint.");
             return null;
         }
 


### PR DESCRIPTION
This PR adds two new features: 

- `HttpClient.GetDidDocAsync` to fetch a users `DidDoc` directly from a given `ATDid`.
- `ATProtocolBuilder.WithInstanceUrl` taking in a `ATDid.` This will resolve and fetch the Service Endpoint (either the PDS or an optional ID/Service Type you pass in). This is useful in cases where you want to resolve to an instance URL from a Did you know. For example, [WhtWnd](https://whtwnd.com/.well-known/did.json) with XRPC endpoints that only exist on those instances.