### PR TITLE
Special case Booleans

### DIFF
--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -59,7 +59,7 @@ public partial class AppCommands
             var directories = GetHighestLevelDirectories(dir);
             foreach (var directory in directories.Where(n => !n.Contains("bsky") && !n.Contains("atproto")))
             {
-                 await this.GenerateClasses(directory);
+                await this.GenerateClasses(directory);
             }
         }
 
@@ -1178,13 +1178,28 @@ public partial class AppCommands
                             {
                                 sb.AppendLine($"            if ({prop} != null)");
                                 sb.AppendLine("            {");
-                                sb.AppendLine($"                queryStrings.Add(\"{prop}=\" + {prop});");
+                                if (typeName.StartsWith("bool"))
+                                {
+                                    sb.AppendLine($"                queryStrings.Add(\"{prop}=\" + ({prop}.Value ? \"true\" : \"false\"));");
+                                }
+                                else
+                                {
+                                    sb.AppendLine($"                queryStrings.Add(\"{prop}=\" + {prop});");
+                                }
+
                                 sb.AppendLine("            }");
                                 sb.AppendLine();
                             }
                             else
                             {
-                                sb.AppendLine($"            queryStrings.Add(\"{prop}=\" + {prop});");
+                                if (typeName.StartsWith("bool"))
+                                {
+                                    sb.AppendLine($"            queryStrings.Add(\"{prop}=\" + ({prop} ? \"true\" : \"false\"));");
+                                }
+                                else
+                                {
+                                    sb.AppendLine($"            queryStrings.Add(\"{prop}=\" + {prop});");
+                                }
                                 sb.AppendLine();
                             }
                         }


### PR DESCRIPTION
Quote from XRPC spec:
> When encoding boolean parameters, the strings `true` and `false` should be used. 
\- https://atproto.com/specs/xrpc#lexicon-http-endpoints

By default, `System.Boolean#ToString()` returns `True` or `False`, I've patched the source generator to add a special case for this, avoiding using `ToString()` in case it runs into any issues with UI culture and the like.

While this appears to generate correctly in my local testing I don't have the complete set of schemas currently included in FishyFlip so I've not actually run the source generator on the repository, happy to do so but I will need pointing towards said schemas.
