### PR TITLE
Add Ozone proxy header

### DIFF
--- a/src/FishyFlip/ATProtocol.cs
+++ b/src/FishyFlip/ATProtocol.cs
@@ -385,6 +385,16 @@ public sealed partial class ATProtocol : IDisposable
         return host;
     }
 
+    /// <summary>
+    /// Sets the Ozone Proxy Header.
+    /// </summary>
+    /// <param name="did">The ATDid of the labeler service. This DID should include an #at_labeler that points to the ozone instance to resolve to.</param>
+    /// <remarks>Sets the Ozone Proxy Header to the given DID.</remarks>
+    public void SetOzoneProxy(ATDid did)
+    {
+        this.options.OzoneProxyHeader = $"{did}{Constants.AtLabeler}";
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/src/FishyFlip/ATProtocolBuilder.cs
+++ b/src/FishyFlip/ATProtocolBuilder.cs
@@ -122,6 +122,17 @@ public class ATProtocolBuilder
     }
 
     /// <summary>
+    /// Sets the ATProtocol Ozone Proxy header.
+    /// </summary>
+    /// <param name="did">The ATDid of the labeler service. This DID should include an #at_labeler that points to the ozone instance to resolve to.</param>
+    /// <returns><see cref="ATProtocolBuilder"/>.</returns>
+    public ATProtocolBuilder WithOzoneProxy(ATDid did)
+    {
+        this.atProtocolOptions.OzoneProxyHeader = $"{did}{Constants.AtLabeler}";
+        return this;
+    }
+
+    /// <summary>
     /// Adds a logger.
     /// </summary>
     /// <param name="logger">Logger.</param>

--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -75,6 +75,11 @@ public class ATProtocolOptions
     public bool UseServiceEndpointUponLogin { get; internal set; } = true;
 
     /// <summary>
+    /// Gets the Ozone Proxy Header.
+    /// </summary>
+    public string OzoneProxyHeader { get; internal set; } = string.Empty;
+
+    /// <summary>
     /// Gets the Did Cache.
     /// </summary>
     internal Dictionary<string, string> DidCache { get; } = new Dictionary<string, string>();

--- a/src/FishyFlip/Constants.cs
+++ b/src/FishyFlip/Constants.cs
@@ -16,6 +16,8 @@ public static class Constants
     internal const string AtProtoAcceptLabelers = "atproto-accept-labelers";
     internal const string AtProtoContentLabelers = "atproto-content-labelers";
     internal const string AtProtoProxy = "atproto-proxy";
+
+    internal const string AtLabeler = "#atproto_labeler";
     internal const string BlueskyChatProxy = "did:web:api.bsky.chat#bsky_chat";
     internal const string BlueskyModerationServiceDid = "did:plc:ar7c4by46qjdydhdevvrndac";
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ActorEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ActorEndpoints.g.cs
@@ -139,9 +139,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         public static Task<Result<Success?>> PutPreferencesAsync (this FishyFlip.ATProtocol atp, List<ATObject> preferences, CancellationToken cancellationToken = default)
         {
             var endpointUrl = PutPreferences.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new PutPreferencesInput();
             inputItem.Preferences = preferences;
-            return atp.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyActorPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedEndpoints.g.cs
@@ -667,9 +667,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput?>> SendInteractionsAsync (this FishyFlip.ATProtocol atp, List<FishyFlip.Lexicon.App.Bsky.Feed.Interaction> interactions, CancellationToken cancellationToken = default)
         {
             var endpointUrl = SendInteractions.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new SendInteractionsInput();
             inputItem.Interactions = interactions;
-            return atp.Post<SendInteractionsInput, FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsInput!, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsOutput!, inputItem, cancellationToken);
+            return atp.Post<SendInteractionsInput, FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsInput!, atp.Options.SourceGenerationContext.AppBskyFeedSendInteractionsOutput!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GraphEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GraphEndpoints.g.cs
@@ -476,9 +476,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         public static Task<Result<Success?>> MuteActorAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default)
         {
             var endpointUrl = MuteActor.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new MuteActorInput();
             inputItem.Actor = actor;
-            return atp.Post<MuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<MuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -492,9 +493,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         public static Task<Result<Success?>> MuteActorListAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATUri list, CancellationToken cancellationToken = default)
         {
             var endpointUrl = MuteActorList.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new MuteActorListInput();
             inputItem.List = list;
-            return atp.Post<MuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorListInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<MuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteActorListInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -508,9 +510,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         public static Task<Result<Success?>> MuteThreadAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATUri root, CancellationToken cancellationToken = default)
         {
             var endpointUrl = MuteThread.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new MuteThreadInput();
             inputItem.Root = root;
-            return atp.Post<MuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteThreadInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<MuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphMuteThreadInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -557,9 +560,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         public static Task<Result<Success?>> UnmuteActorAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UnmuteActor.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UnmuteActorInput();
             inputItem.Actor = actor;
-            return atp.Post<UnmuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UnmuteActorInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -573,9 +577,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         public static Task<Result<Success?>> UnmuteActorListAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATUri list, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UnmuteActorList.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UnmuteActorListInput();
             inputItem.List = list;
-            return atp.Post<UnmuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorListInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UnmuteActorListInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteActorListInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -589,9 +594,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         public static Task<Result<Success?>> UnmuteThreadAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATUri root, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UnmuteThread.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UnmuteThreadInput();
             inputItem.Root = root;
-            return atp.Post<UnmuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteThreadInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UnmuteThreadInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyGraphUnmuteThreadInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Notification/NotificationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Notification/NotificationEndpoints.g.cs
@@ -112,9 +112,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
         public static Task<Result<Success?>> PutPreferencesAsync (this FishyFlip.ATProtocol atp, bool priority, CancellationToken cancellationToken = default)
         {
             var endpointUrl = PutPreferences.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new PutPreferencesInput();
             inputItem.Priority = priority;
-            return atp.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<PutPreferencesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationPutPreferencesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -131,12 +132,13 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
         public static Task<Result<Success?>> RegisterPushAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid serviceDid, string token, string platform, string appId, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RegisterPush.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new RegisterPushInput();
             inputItem.ServiceDid = serviceDid;
             inputItem.Token = token;
             inputItem.Platform = platform;
             inputItem.AppId = appId;
-            return atp.Post<RegisterPushInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationRegisterPushInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<RegisterPushInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationRegisterPushInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -150,9 +152,10 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
         public static Task<Result<Success?>> UpdateSeenAsync (this FishyFlip.ATProtocol atp, DateTime seenAt, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateSeen.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UpdateSeenInput();
             inputItem.SeenAt = seenAt;
-            return atp.Post<UpdateSeenInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationUpdateSeenInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UpdateSeenInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyNotificationUpdateSeenInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/App/Bsky/Video/VideoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Video/VideoEndpoints.g.cs
@@ -65,7 +65,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Video
         public static Task<Result<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput?>> UploadVideoAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UploadVideo.ToString();
-            return atp.Post<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoUploadVideoOutput!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.AppBskyVideoUploadVideoOutput!, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ActorEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ActorEndpoints.g.cs
@@ -27,7 +27,9 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput?>> DeleteAccountAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteAccount.ToString();
-            return atp.Post<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyActorDeleteAccountOutput!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
+            return atp.Post<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyActorDeleteAccountOutput!, cancellationToken, headers);
         }
 
 

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoEndpoints.g.cs
@@ -49,10 +49,12 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView?>> DeleteMessageForSelfAsync (this FishyFlip.ATProtocol atp, string convoId, string messageId, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteMessageForSelf.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new DeleteMessageForSelfInput();
             inputItem.ConvoId = convoId;
             inputItem.MessageId = messageId;
-            return atp.Post<DeleteMessageForSelfInput, FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoDeleteMessageForSelfInput!, atp.Options.SourceGenerationContext.ChatBskyConvoDeletedMessageView!, inputItem, cancellationToken);
+            return atp.Post<DeleteMessageForSelfInput, FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoDeleteMessageForSelfInput!, atp.Options.SourceGenerationContext.ChatBskyConvoDeletedMessageView!, inputItem, cancellationToken, headers);
         }
 
 
@@ -169,9 +171,11 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput?>> LeaveConvoAsync (this FishyFlip.ATProtocol atp, string convoId, CancellationToken cancellationToken = default)
         {
             var endpointUrl = LeaveConvo.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new LeaveConvoInput();
             inputItem.ConvoId = convoId;
-            return atp.Post<LeaveConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoOutput!, inputItem, cancellationToken);
+            return atp.Post<LeaveConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoLeaveConvoOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -216,9 +220,11 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput?>> MuteConvoAsync (this FishyFlip.ATProtocol atp, string convoId, CancellationToken cancellationToken = default)
         {
             var endpointUrl = MuteConvo.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new MuteConvoInput();
             inputItem.ConvoId = convoId;
-            return atp.Post<MuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoOutput!, inputItem, cancellationToken);
+            return atp.Post<MuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMuteConvoOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -233,10 +239,12 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView?>> SendMessageAsync (this FishyFlip.ATProtocol atp, string convoId, FishyFlip.Lexicon.Chat.Bsky.Convo.MessageInput message, CancellationToken cancellationToken = default)
         {
             var endpointUrl = SendMessage.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new SendMessageInput();
             inputItem.ConvoId = convoId;
             inputItem.Message = message;
-            return atp.Post<SendMessageInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMessageView!, inputItem, cancellationToken);
+            return atp.Post<SendMessageInput, FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageInput!, atp.Options.SourceGenerationContext.ChatBskyConvoMessageView!, inputItem, cancellationToken, headers);
         }
 
 
@@ -250,9 +258,11 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput?>> SendMessageBatchAsync (this FishyFlip.ATProtocol atp, List<FishyFlip.Lexicon.Chat.Bsky.Convo.BatchItem> items, CancellationToken cancellationToken = default)
         {
             var endpointUrl = SendMessageBatch.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new SendMessageBatchInput();
             inputItem.Items = items;
-            return atp.Post<SendMessageBatchInput, FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchInput!, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchOutput!, inputItem, cancellationToken);
+            return atp.Post<SendMessageBatchInput, FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchInput!, atp.Options.SourceGenerationContext.ChatBskyConvoSendMessageBatchOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -266,9 +276,11 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput?>> UnmuteConvoAsync (this FishyFlip.ATProtocol atp, string convoId, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UnmuteConvo.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new UnmuteConvoInput();
             inputItem.ConvoId = convoId;
-            return atp.Post<UnmuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoOutput!, inputItem, cancellationToken);
+            return atp.Post<UnmuteConvoInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUnmuteConvoOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -283,10 +295,12 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         public static Task<Result<FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput?>> UpdateReadAsync (this FishyFlip.ATProtocol atp, string convoId, string? messageId = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateRead.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new UpdateReadInput();
             inputItem.ConvoId = convoId;
             inputItem.MessageId = messageId;
-            return atp.Post<UpdateReadInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadOutput!, inputItem, cancellationToken);
+            return atp.Post<UpdateReadInput, FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadInput!, atp.Options.SourceGenerationContext.ChatBskyConvoUpdateReadOutput!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
@@ -94,11 +94,13 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
         public static Task<Result<Success?>> UpdateActorAccessAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid actor, bool allowAccess, string? @ref = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateActorAccess.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
             var inputItem = new UpdateActorAccessInput();
             inputItem.Actor = actor;
             inputItem.AllowAccess = allowAccess;
             inputItem.Ref = @ref;
-            return atp.Post<UpdateActorAccessInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationUpdateActorAccessInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UpdateActorAccessInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationUpdateActorAccessInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
@@ -52,9 +52,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<Success?>> DeleteAccountAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteAccount.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new DeleteAccountInput();
             inputItem.Did = did;
-            return atp.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -69,10 +70,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<Success?>> DisableAccountInvitesAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid account, string? note = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DisableAccountInvites.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new DisableAccountInvitesInput();
             inputItem.Account = account;
             inputItem.Note = note;
-            return atp.Post<DisableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DisableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -87,10 +89,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<Success?>> DisableInviteCodesAsync (this FishyFlip.ATProtocol atp, List<string>? codes = default, List<string>? accounts = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DisableInviteCodes.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new DisableInviteCodesInput();
             inputItem.Codes = codes;
             inputItem.Accounts = accounts;
-            return atp.Post<DisableInviteCodesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableInviteCodesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DisableInviteCodesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminDisableInviteCodesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -105,10 +108,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<Success?>> EnableAccountInvitesAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid account, string? note = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = EnableAccountInvites.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new EnableAccountInvitesInput();
             inputItem.Account = account;
             inputItem.Note = note;
-            return atp.Post<EnableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminEnableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<EnableAccountInvitesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminEnableAccountInvitesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -276,13 +280,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput?>> SendEmailAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid recipientDid, string content, FishyFlip.Models.ATDid senderDid, string? subject = default, string? comment = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = SendEmail.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new SendEmailInput();
             inputItem.RecipientDid = recipientDid;
             inputItem.Content = content;
             inputItem.SenderDid = senderDid;
             inputItem.Subject = subject;
             inputItem.Comment = comment;
-            return atp.Post<SendEmailInput, FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailOutput!, inputItem, cancellationToken);
+            return atp.Post<SendEmailInput, FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminSendEmailOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -297,10 +302,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<Success?>> UpdateAccountEmailAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATIdentifier account, string email, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateAccountEmail.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UpdateAccountEmailInput();
             inputItem.Account = account;
             inputItem.Email = email;
-            return atp.Post<UpdateAccountEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UpdateAccountEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -315,10 +321,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<Success?>> UpdateAccountHandleAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, FishyFlip.Models.ATHandle handle, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateAccountHandle.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UpdateAccountHandleInput();
             inputItem.Did = did;
             inputItem.Handle = handle;
-            return atp.Post<UpdateAccountHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountHandleInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UpdateAccountHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountHandleInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -333,10 +340,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<Success?>> UpdateAccountPasswordAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, string password, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateAccountPassword.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UpdateAccountPasswordInput();
             inputItem.Did = did;
             inputItem.Password = password;
-            return atp.Post<UpdateAccountPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UpdateAccountPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateAccountPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -352,11 +360,12 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput?>> UpdateSubjectStatusAsync (this FishyFlip.ATProtocol atp, ATObject subject, FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr? takedown = default, FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr? deactivated = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateSubjectStatus.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UpdateSubjectStatusInput();
             inputItem.Subject = subject;
             inputItem.Takedown = takedown;
             inputItem.Deactivated = deactivated;
-            return atp.Post<UpdateSubjectStatusInput, FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusOutput!, inputItem, cancellationToken);
+            return atp.Post<UpdateSubjectStatusInput, FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusInput!, atp.Options.SourceGenerationContext.ComAtprotoAdminUpdateSubjectStatusOutput!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Identity/IdentityEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Identity/IdentityEndpoints.g.cs
@@ -50,7 +50,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         public static Task<Result<Success?>> RequestPlcOperationSignatureAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestPlcOperationSignature.ToString();
-            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken, headers);
         }
 
 
@@ -89,13 +90,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput?>> SignPlcOperationAsync (this FishyFlip.ATProtocol atp, string? token = default, List<string>? rotationKeys = default, List<string>? alsoKnownAs = default, ATObject? verificationMethods = default, ATObject? services = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = SignPlcOperation.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new SignPlcOperationInput();
             inputItem.Token = token;
             inputItem.RotationKeys = rotationKeys;
             inputItem.AlsoKnownAs = alsoKnownAs;
             inputItem.VerificationMethods = verificationMethods;
             inputItem.Services = services;
-            return atp.Post<SignPlcOperationInput, FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationInput!, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationOutput!, inputItem, cancellationToken);
+            return atp.Post<SignPlcOperationInput, FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationInput!, atp.Options.SourceGenerationContext.ComAtprotoIdentitySignPlcOperationOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -109,9 +111,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         public static Task<Result<Success?>> SubmitPlcOperationAsync (this FishyFlip.ATProtocol atp, ATObject operation, CancellationToken cancellationToken = default)
         {
             var endpointUrl = SubmitPlcOperation.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new SubmitPlcOperationInput();
             inputItem.Operation = operation;
-            return atp.Post<SubmitPlcOperationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySubmitPlcOperationInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<SubmitPlcOperationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentitySubmitPlcOperationInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -125,9 +128,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         public static Task<Result<Success?>> UpdateHandleAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATHandle handle, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateHandle.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UpdateHandleInput();
             inputItem.Handle = handle;
-            return atp.Post<UpdateHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityUpdateHandleInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UpdateHandleInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityUpdateHandleInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
@@ -37,11 +37,12 @@ namespace FishyFlip.Lexicon.Com.Atproto.Moderation
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput?>> CreateReportAsync (this FishyFlip.ATProtocol atp, string reasonType, ATObject subject, string? reason = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateReport.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new CreateReportInput();
             inputItem.ReasonType = reasonType;
             inputItem.Subject = subject;
             inputItem.Reason = reason;
-            return atp.Post<CreateReportInput, FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportInput!, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportOutput!, inputItem, cancellationToken);
+            return atp.Post<CreateReportInput, FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportInput!, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportOutput!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/RepoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/RepoEndpoints.g.cs
@@ -49,12 +49,13 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput?>> ApplyWritesAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATIdentifier repo, List<ATObject> writes, bool? validate = default, string? swapCommit = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ApplyWrites.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new ApplyWritesInput();
             inputItem.Repo = repo;
             inputItem.Writes = writes;
             inputItem.Validate = validate;
             inputItem.SwapCommit = swapCommit;
-            return atp.Post<ApplyWritesInput, FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesOutput!, inputItem, cancellationToken);
+            return atp.Post<ApplyWritesInput, FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoApplyWritesOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -75,6 +76,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput?>> CreateRecordAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATIdentifier repo, string collection, ATObject record, string? rkey = default, bool? validate = default, string? swapCommit = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateRecord.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new CreateRecordInput();
             inputItem.Repo = repo;
             inputItem.Collection = collection;
@@ -82,7 +84,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             inputItem.Rkey = rkey;
             inputItem.Validate = validate;
             inputItem.SwapCommit = swapCommit;
-            return atp.Post<CreateRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordOutput!, inputItem, cancellationToken);
+            return atp.Post<CreateRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoCreateRecordOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -102,13 +104,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput?>> DeleteRecordAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATIdentifier repo, string collection, string rkey, string? swapRecord = default, string? swapCommit = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteRecord.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new DeleteRecordInput();
             inputItem.Repo = repo;
             inputItem.Collection = collection;
             inputItem.Rkey = rkey;
             inputItem.SwapRecord = swapRecord;
             inputItem.SwapCommit = swapCommit;
-            return atp.Post<DeleteRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordOutput!, inputItem, cancellationToken);
+            return atp.Post<DeleteRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoDeleteRecordOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -178,7 +181,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<Success?>> ImportRepoAsync (this FishyFlip.ATProtocol atp, StreamContent content, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ImportRepo.ToString();
-            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, content, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, content, cancellationToken, headers);
         }
 
 
@@ -272,6 +276,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput?>> PutRecordAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATIdentifier repo, string collection, string rkey, ATObject record, bool? validate = default, string? swapRecord = default, string? swapCommit = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = PutRecord.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new PutRecordInput();
             inputItem.Repo = repo;
             inputItem.Collection = collection;
@@ -280,7 +285,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             inputItem.Validate = validate;
             inputItem.SwapRecord = swapRecord;
             inputItem.SwapCommit = swapCommit;
-            return atp.Post<PutRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordOutput!, inputItem, cancellationToken);
+            return atp.Post<PutRecordInput, FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordInput!, atp.Options.SourceGenerationContext.ComAtprotoRepoPutRecordOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -294,7 +299,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput?>> UploadBlobAsync (this FishyFlip.ATProtocol atp, StreamContent content, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UploadBlob.ToString();
-            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoUploadBlobOutput!, content, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoUploadBlobOutput!, content, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/ServerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/ServerEndpoints.g.cs
@@ -73,7 +73,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> ActivateAccountAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ActivateAccount.ToString();
-            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken, headers);
         }
 
 
@@ -108,10 +109,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> ConfirmEmailAsync (this FishyFlip.ATProtocol atp, string email, string token, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ConfirmEmail.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new ConfirmEmailInput();
             inputItem.Email = email;
             inputItem.Token = token;
-            return atp.Post<ConfirmEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerConfirmEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<ConfirmEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerConfirmEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -141,6 +143,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput?>> CreateAccountAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATHandle handle, string? email = default, FishyFlip.Models.ATDid? did = default, string? inviteCode = default, string? verificationCode = default, string? verificationPhone = default, string? password = default, string? recoveryKey = default, ATObject? plcOp = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateAccount.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new CreateAccountInput();
             inputItem.Handle = handle;
             inputItem.Email = email;
@@ -151,7 +154,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             inputItem.Password = password;
             inputItem.RecoveryKey = recoveryKey;
             inputItem.PlcOp = plcOp;
-            return atp.Post<CreateAccountInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountOutput!, inputItem, cancellationToken);
+            return atp.Post<CreateAccountInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAccountOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -168,10 +171,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.AppPasswordDef?>> CreateAppPasswordAsync (this FishyFlip.ATProtocol atp, string name, bool? privileged = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateAppPassword.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new CreateAppPasswordInput();
             inputItem.Name = name;
             inputItem.Privileged = privileged;
-            return atp.Post<CreateAppPasswordInput, FishyFlip.Lexicon.Com.Atproto.Server.AppPasswordDef?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAppPasswordInput!, atp.Options.SourceGenerationContext.ComAtprotoServerAppPasswordDef!, inputItem, cancellationToken);
+            return atp.Post<CreateAppPasswordInput, FishyFlip.Lexicon.Com.Atproto.Server.AppPasswordDef?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateAppPasswordInput!, atp.Options.SourceGenerationContext.ComAtprotoServerAppPasswordDef!, inputItem, cancellationToken, headers);
         }
 
 
@@ -186,10 +190,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput?>> CreateInviteCodeAsync (this FishyFlip.ATProtocol atp, int useCount, FishyFlip.Models.ATDid? forAccount = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateInviteCode.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new CreateInviteCodeInput();
             inputItem.UseCount = useCount;
             inputItem.ForAccount = forAccount;
-            return atp.Post<CreateInviteCodeInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeOutput!, inputItem, cancellationToken);
+            return atp.Post<CreateInviteCodeInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodeOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -205,11 +210,12 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput?>> CreateInviteCodesAsync (this FishyFlip.ATProtocol atp, int codeCount, int useCount, List<FishyFlip.Models.ATDid>? forAccounts = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateInviteCodes.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new CreateInviteCodesInput();
             inputItem.CodeCount = codeCount;
             inputItem.UseCount = useCount;
             inputItem.ForAccounts = forAccounts;
-            return atp.Post<CreateInviteCodesInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesOutput!, inputItem, cancellationToken);
+            return atp.Post<CreateInviteCodesInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateInviteCodesOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -229,12 +235,13 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput?>> CreateSessionAsync (this FishyFlip.ATProtocol atp, string identifier, string password, string? authFactorToken = default, bool? allowTakendown = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateSession.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new CreateSessionInput();
             inputItem.Identifier = identifier;
             inputItem.Password = password;
             inputItem.AuthFactorToken = authFactorToken;
             inputItem.AllowTakendown = allowTakendown;
-            return atp.Post<CreateSessionInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionOutput!, inputItem, cancellationToken);
+            return atp.Post<CreateSessionInput, FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionInput!, atp.Options.SourceGenerationContext.ComAtprotoServerCreateSessionOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -248,9 +255,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> DeactivateAccountAsync (this FishyFlip.ATProtocol atp, DateTime? deleteAfter = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeactivateAccount.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new DeactivateAccountInput();
             inputItem.DeleteAfter = deleteAfter;
-            return atp.Post<DeactivateAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeactivateAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DeactivateAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeactivateAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -269,11 +277,12 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> DeleteAccountAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, string password, string token, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteAccount.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new DeleteAccountInput();
             inputItem.Did = did;
             inputItem.Password = password;
             inputItem.Token = token;
-            return atp.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DeleteAccountInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDeleteAccountInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -286,7 +295,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> DeleteSessionAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteSession.ToString();
-            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken, headers);
         }
 
 
@@ -415,7 +425,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput?>> RefreshSessionAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RefreshSession.ToString();
-            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRefreshSessionOutput!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRefreshSessionOutput!, cancellationToken, headers);
         }
 
 
@@ -428,7 +439,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> RequestAccountDeleteAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestAccountDelete.ToString();
-            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken, headers);
         }
 
 
@@ -441,7 +453,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> RequestEmailConfirmationAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestEmailConfirmation.ToString();
-            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<Success?>(endpointUrl, atp.Options.SourceGenerationContext.Success!, cancellationToken, headers);
         }
 
 
@@ -454,7 +467,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput?>> RequestEmailUpdateAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestEmailUpdate.ToString();
-            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestEmailUpdateOutput!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            return atp.Post<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestEmailUpdateOutput!, cancellationToken, headers);
         }
 
 
@@ -468,9 +482,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> RequestPasswordResetAsync (this FishyFlip.ATProtocol atp, string email, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestPasswordReset.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new RequestPasswordResetInput();
             inputItem.Email = email;
-            return atp.Post<RequestPasswordResetInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestPasswordResetInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<RequestPasswordResetInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRequestPasswordResetInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -484,9 +499,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput?>> ReserveSigningKeyAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid? did = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ReserveSigningKey.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new ReserveSigningKeyInput();
             inputItem.Did = did;
-            return atp.Post<ReserveSigningKeyInput, FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyInput!, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyOutput!, inputItem, cancellationToken);
+            return atp.Post<ReserveSigningKeyInput, FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyInput!, atp.Options.SourceGenerationContext.ComAtprotoServerReserveSigningKeyOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -504,10 +520,11 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> ResetPasswordAsync (this FishyFlip.ATProtocol atp, string token, string password, CancellationToken cancellationToken = default)
         {
             var endpointUrl = ResetPassword.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new ResetPasswordInput();
             inputItem.Token = token;
             inputItem.Password = password;
-            return atp.Post<ResetPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerResetPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<ResetPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerResetPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -521,9 +538,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> RevokeAppPasswordAsync (this FishyFlip.ATProtocol atp, string name, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RevokeAppPassword.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new RevokeAppPasswordInput();
             inputItem.Name = name;
-            return atp.Post<RevokeAppPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRevokeAppPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<RevokeAppPasswordInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerRevokeAppPasswordInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -543,11 +561,12 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         public static Task<Result<Success?>> UpdateEmailAsync (this FishyFlip.ATProtocol atp, string email, bool? emailAuthFactor = default, string? token = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateEmail.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new UpdateEmailInput();
             inputItem.Email = email;
             inputItem.EmailAuthFactor = emailAuthFactor;
             inputItem.Token = token;
-            return atp.Post<UpdateEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerUpdateEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<UpdateEmailInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerUpdateEmailInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
@@ -301,9 +301,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         public static Task<Result<Success?>> NotifyOfUpdateAsync (this FishyFlip.ATProtocol atp, string hostname, CancellationToken cancellationToken = default)
         {
             var endpointUrl = NotifyOfUpdate.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new NotifyOfUpdateInput();
             inputItem.Hostname = hostname;
-            return atp.Post<NotifyOfUpdateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncNotifyOfUpdateInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<NotifyOfUpdateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncNotifyOfUpdateInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -317,9 +318,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         public static Task<Result<Success?>> RequestCrawlAsync (this FishyFlip.ATProtocol atp, string hostname, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestCrawl.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new RequestCrawlInput();
             inputItem.Hostname = hostname;
-            return atp.Post<RequestCrawlInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncRequestCrawlInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<RequestCrawlInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncRequestCrawlInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Temp/TempEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Temp/TempEndpoints.g.cs
@@ -30,9 +30,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
         public static Task<Result<FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput?>> AddReservedHandleAsync (this FishyFlip.ATProtocol atp, string handle, CancellationToken cancellationToken = default)
         {
             var endpointUrl = AddReservedHandle.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new AddReservedHandleInput();
             inputItem.Handle = handle;
-            return atp.Post<AddReservedHandleInput, FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleInput!, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleOutput!, inputItem, cancellationToken);
+            return atp.Post<AddReservedHandleInput, FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleInput!, atp.Options.SourceGenerationContext.ComAtprotoTempAddReservedHandleOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -61,9 +62,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
         public static Task<Result<Success?>> RequestPhoneVerificationAsync (this FishyFlip.ATProtocol atp, string phoneNumber, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RequestPhoneVerification.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new RequestPhoneVerificationInput();
             inputItem.PhoneNumber = phoneNumber;
-            return atp.Post<RequestPhoneVerificationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempRequestPhoneVerificationInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<RequestPhoneVerificationInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempRequestPhoneVerificationInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEndpoints.g.cs
@@ -100,9 +100,10 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         public static Task<Result<FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput?>> NotifyOfNewEntryAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATUri entryUri, CancellationToken cancellationToken = default)
         {
             var endpointUrl = NotifyOfNewEntry.ToString();
+            var headers = new Dictionary<string, string>();
             var inputItem = new NotifyOfNewEntryInput();
             inputItem.EntryUri = entryUri;
-            return atp.Post<NotifyOfNewEntryInput, FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryInput!, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryOutput!, inputItem, cancellationToken);
+            return atp.Post<NotifyOfNewEntryInput, FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryInput!, atp.Options.SourceGenerationContext.ComWhtwndBlogNotifyOfNewEntryOutput!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
@@ -38,13 +38,15 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>> CreateTemplateAsync (this FishyFlip.ATProtocol atp, string name, string contentMarkdown, string subject, string? lang = default, FishyFlip.Models.ATDid? createdBy = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = CreateTemplate.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new CreateTemplateInput();
             inputItem.Name = name;
             inputItem.ContentMarkdown = contentMarkdown;
             inputItem.Subject = subject;
             inputItem.Lang = lang;
             inputItem.CreatedBy = createdBy;
-            return atp.Post<CreateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationCreateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, inputItem, cancellationToken);
+            return atp.Post<CreateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationCreateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, inputItem, cancellationToken, headers);
         }
 
 
@@ -58,9 +60,11 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         public static Task<Result<Success?>> DeleteTemplateAsync (this FishyFlip.ATProtocol atp, string id, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteTemplate.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new DeleteTemplateInput();
             inputItem.Id = id;
-            return atp.Post<DeleteTemplateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationDeleteTemplateInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DeleteTemplateInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationDeleteTemplateInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -98,6 +102,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>> UpdateTemplateAsync (this FishyFlip.ATProtocol atp, string id, string? name = default, string? lang = default, string? contentMarkdown = default, string? subject = default, FishyFlip.Models.ATDid? updatedBy = default, bool? disabled = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateTemplate.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new UpdateTemplateInput();
             inputItem.Id = id;
             inputItem.Name = name;
@@ -106,7 +112,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
             inputItem.Subject = subject;
             inputItem.UpdatedBy = updatedBy;
             inputItem.Disabled = disabled;
-            return atp.Post<UpdateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationUpdateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, inputItem, cancellationToken);
+            return atp.Post<UpdateTemplateInput, FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationUpdateTemplateInput!, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationTemplateView!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
@@ -74,6 +74,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         {
             var endpointUrl = ListTemplates.ToString();
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Communication.ListTemplatesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneCommunicationListTemplatesOutput!, cancellationToken, headers);
         }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
@@ -71,6 +71,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add("id=" + id);
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationModEventViewDetail!, cancellationToken, headers);
@@ -100,6 +101,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationRecordViewDetail!, cancellationToken, headers);
@@ -121,6 +123,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add(string.Join("&", uris.Select(n => "uris=" + n)));
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetRecordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationGetRecordsOutput!, cancellationToken, headers);
@@ -144,6 +147,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add("did=" + did);
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationRepoViewDetail!, cancellationToken, headers);
@@ -165,6 +169,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             queryStrings.Add(string.Join("&", dids.Select(n => "dids=" + n)));
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationGetReposOutput!, cancellationToken, headers);
@@ -297,6 +302,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryEventsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationQueryEventsOutput!, cancellationToken, headers);
@@ -495,6 +501,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryStatusesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationQueryStatusesOutput!, cancellationToken, headers);
@@ -531,6 +538,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Moderation.SearchReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationSearchReposOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
@@ -47,12 +47,14 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView?>> EmitEventAsync (this FishyFlip.ATProtocol atp, ATObject @event, ATObject subject, FishyFlip.Models.ATDid createdBy, List<string>? subjectBlobCids = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = EmitEvent.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new EmitEventInput();
             inputItem.Event = @event;
             inputItem.Subject = subject;
             inputItem.CreatedBy = createdBy;
             inputItem.SubjectBlobCids = subjectBlobCids;
-            return atp.Post<EmitEventInput, FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationEmitEventInput!, atp.Options.SourceGenerationContext.ToolsOzoneModerationModEventView!, inputItem, cancellationToken);
+            return atp.Post<EmitEventInput, FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneModerationEmitEventInput!, atp.Options.SourceGenerationContext.ToolsOzoneModerationModEventView!, inputItem, cancellationToken, headers);
         }
 
 

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServerEndpoints.g.cs
@@ -26,6 +26,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         {
             var endpointUrl = GetConfig.ToString();
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Server.GetConfigOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneServerGetConfigOutput!, cancellationToken, headers);
         }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
@@ -111,6 +111,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Set.GetValuesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetGetValuesOutput!, cancellationToken, headers);
@@ -159,6 +160,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Set.QuerySetsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetQuerySetsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
@@ -37,10 +37,12 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         public static Task<Result<Success?>> AddValuesAsync (this FishyFlip.ATProtocol atp, string name, List<string> values, CancellationToken cancellationToken = default)
         {
             var endpointUrl = AddValues.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new AddValuesInput();
             inputItem.Name = name;
             inputItem.Values = values;
-            return atp.Post<AddValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetAddValuesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<AddValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetAddValuesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -56,9 +58,11 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput?>> DeleteSetAsync (this FishyFlip.ATProtocol atp, string name, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteSet.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new DeleteSetInput();
             inputItem.Name = name;
-            return atp.Post<DeleteSetInput, FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetInput!, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetOutput!, inputItem, cancellationToken);
+            return atp.Post<DeleteSetInput, FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetInput!, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteSetOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -75,10 +79,12 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         public static Task<Result<Success?>> DeleteValuesAsync (this FishyFlip.ATProtocol atp, string name, List<string> values, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteValues.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new DeleteValuesInput();
             inputItem.Name = name;
             inputItem.Values = values;
-            return atp.Post<DeleteValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteValuesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DeleteValuesInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetDeleteValuesInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -176,7 +182,9 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Set.SetView?>> UpsertSetAsync (this FishyFlip.ATProtocol atp, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpsertSet.ToString();
-            return atp.Post<FishyFlip.Lexicon.Tools.Ozone.Set.SetView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetSetView!, cancellationToken);
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
+            return atp.Post<FishyFlip.Lexicon.Tools.Ozone.Set.SetView?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSetSetView!, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
@@ -80,10 +80,12 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput?>> RemoveOptionsAsync (this FishyFlip.ATProtocol atp, List<string> keys, string scope, CancellationToken cancellationToken = default)
         {
             var endpointUrl = RemoveOptions.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new RemoveOptionsInput();
             inputItem.Keys = keys;
             inputItem.Scope = scope;
-            return atp.Post<RemoveOptionsInput, FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsOutput!, inputItem, cancellationToken);
+            return atp.Post<RemoveOptionsInput, FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingRemoveOptionsOutput!, inputItem, cancellationToken, headers);
         }
 
 
@@ -101,13 +103,15 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput?>> UpsertOptionAsync (this FishyFlip.ATProtocol atp, string key, string scope, ATObject value, string? description = default, string? managerRole = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpsertOption.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new UpsertOptionInput();
             inputItem.Key = key;
             inputItem.Scope = scope;
             inputItem.Value = value;
             inputItem.Description = description;
             inputItem.ManagerRole = managerRole;
-            return atp.Post<UpsertOptionInput, FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionOutput!, inputItem, cancellationToken);
+            return atp.Post<UpsertOptionInput, FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionInput!, atp.Options.SourceGenerationContext.ToolsOzoneSettingUpsertOptionOutput!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
@@ -62,6 +62,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Setting.ListOptionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSettingListOptionsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SignatureEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SignatureEndpoints.g.cs
@@ -35,6 +35,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
             queryStrings.Add(string.Join("&", dids.Select(n => "dids=" + n)));
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.FindCorrelationOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureFindCorrelationOutput!, cancellationToken, headers);
@@ -68,6 +69,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.FindRelatedAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureFindRelatedAccountsOutput!, cancellationToken, headers);
@@ -101,6 +103,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Signature.SearchAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneSignatureSearchAccountsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
@@ -85,6 +85,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
             }
 
             var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Tools.Ozone.Team.ListMembersOutput>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamListMembersOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
@@ -35,10 +35,12 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Team.Member?>> AddMemberAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, string role, CancellationToken cancellationToken = default)
         {
             var endpointUrl = AddMember.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new AddMemberInput();
             inputItem.Did = did;
             inputItem.Role = role;
-            return atp.Post<AddMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamAddMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, inputItem, cancellationToken);
+            return atp.Post<AddMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamAddMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, inputItem, cancellationToken, headers);
         }
 
 
@@ -55,9 +57,11 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         public static Task<Result<Success?>> DeleteMemberAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default)
         {
             var endpointUrl = DeleteMember.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new DeleteMemberInput();
             inputItem.Did = did;
-            return atp.Post<DeleteMemberInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamDeleteMemberInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken);
+            return atp.Post<DeleteMemberInput, Success?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamDeleteMemberInput!, atp.Options.SourceGenerationContext.Success!, inputItem, cancellationToken, headers);
         }
 
 
@@ -106,11 +110,13 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         public static Task<Result<FishyFlip.Lexicon.Tools.Ozone.Team.Member?>> UpdateMemberAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, bool? disabled = default, string? role = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = UpdateMember.ToString();
+            var headers = new Dictionary<string, string>();
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new UpdateMemberInput();
             inputItem.Did = did;
             inputItem.Disabled = disabled;
             inputItem.Role = role;
-            return atp.Post<UpdateMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamUpdateMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, inputItem, cancellationToken);
+            return atp.Post<UpdateMemberInput, FishyFlip.Lexicon.Tools.Ozone.Team.Member?>(endpointUrl, atp.Options.SourceGenerationContext.ToolsOzoneTeamUpdateMemberInput!, atp.Options.SourceGenerationContext.ToolsOzoneTeamMember!, inputItem, cancellationToken, headers);
         }
 
     }

--- a/src/FishyFlip/Tools/ATProtocolExtensions.cs
+++ b/src/FishyFlip/Tools/ATProtocolExtensions.cs
@@ -92,15 +92,17 @@ public static class ATProtocolExtensions
     /// <param name="url">The Uri the request is sent to.</param>
     /// <param name="type">The JsonTypeInfo of the response body.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <param name="headers">Custom headers to include with the request.</param>
     /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Http response message as the result.</returns>
     public static async Task<Result<TK>> Post<TK>(
         this ATProtocol protocol,
         string url,
         JsonTypeInfo<TK> type,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Dictionary<string, string>? headers = null)
     {
         var result = await protocol.ResolveHostUri(url);
-        return await protocol.Client.Post<TK>(result, type, protocol.Options.JsonSerializerOptions, cancellationToken, protocol.Options.Logger);
+        return await protocol.Client.Post<TK>(result, type, protocol.Options.JsonSerializerOptions, cancellationToken, protocol.Options.Logger, headers);
     }
 
     /// <summary>
@@ -112,15 +114,25 @@ public static class ATProtocolExtensions
     /// <param name="type">The JsonTypeInfo of the response body.</param>
     /// <param name="body">The StreamContent request body.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <param name="headers">Custom headers to include with the request.</param>
     /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Http response message as the result.</returns>
     public static async Task<Result<TK>> Post<TK>(
        this ATProtocol protocol,
        string url,
        JsonTypeInfo<TK> type,
        StreamContent body,
-       CancellationToken cancellationToken)
+       CancellationToken cancellationToken,
+       Dictionary<string, string>? headers = default)
     {
         var result = await protocol.ResolveHostUri(url);
+        if (headers is not null)
+        {
+            foreach (var header in headers)
+            {
+                body.Headers.Add(header.Key, header.Value);
+            }
+        }
+
         return await protocol.Client.Post<TK>(result, type, protocol.Options.JsonSerializerOptions, body, cancellationToken, protocol.Options.Logger);
     }
 

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -1211,6 +1211,11 @@ public partial class AppCommands
                         sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);");
                     }
 
+                    if (item.Id.Contains("ozone"))
+                    {
+                        sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
+                    }
+
                     sb.AppendLine($"            headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);");
 
                     if (inputProperties.Count > 2)

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -1114,15 +1114,24 @@ public partial class AppCommands
             {
                 case "procedure":
                     sb.AppendLine($"            var endpointUrl = {item.ClassName}.ToString();");
+                    sb.AppendLine($"            var headers = new Dictionary<string, string>();");
+                    if (item.Id.Contains("ozone"))
+                    {
+                        sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
+                    }
+                    if (item.Id.Contains("chat"))
+                    {
+                        sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);");
+                    }
                     if (inputProperties.Count <= 2)
                     {
                         sb.AppendLine(
-                            $"            return atp.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, cancellationToken);");
+                            $"            return atp.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, cancellationToken, headers);");
                     }
                     else if (inputProperties[1].Contains("StreamContent"))
                     {
                         sb.AppendLine(
-                            $"            return atp.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, {inputProperties[1].Split(" ").Last()}, cancellationToken);");
+                            $"            return atp.Post<{outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{sourceContext}!, {inputProperties[1].Split(" ").Last()}, cancellationToken, headers);");
                     }
                     else
                     {
@@ -1137,7 +1146,7 @@ public partial class AppCommands
                         }
 
                         sb.AppendLine(
-                            $"            return atp.Post<{item.ClassName}Input, {outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{inputSourceContext}!, atp.Options.SourceGenerationContext.{sourceContext}!, inputItem, cancellationToken);");
+                            $"            return atp.Post<{item.ClassName}Input, {outputProperty}?>(endpointUrl, atp.Options.SourceGenerationContext.{inputSourceContext}!, atp.Options.SourceGenerationContext.{sourceContext}!, inputItem, cancellationToken, headers);");
                     }
 
                     break;


### PR DESCRIPTION
To support Ozone, we need to add the `at_labeler` proxy header to requests for them to be properly routed. This PR addresses that.

Fixes #142 

<img width="694" alt="スクリーンショット 2025-01-04 9 50 36" src="https://github.com/user-attachments/assets/94712262-7fe7-413e-b332-76cb1d60c1ac" />

To use, either add `AtProtocolBuilder.WithOzoneProxy(ATDid)` with the DID of the labeler service or set `ATProtocol.SetOzoneProxy(ATDid)` with said ATDid.

