### PR TITLE
Switch Chat Moderation endpoints to use ozone

### DIFF
--- a/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
@@ -35,7 +35,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
             queryStrings.Add("actor=" + actor);
 
             var headers = new Dictionary<string, string>();
-            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetActorMetadataOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationGetActorMetadataOutput!, cancellationToken, headers);
@@ -75,7 +75,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
             }
 
             var headers = new Dictionary<string, string>();
-            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetMessageContextOutput>(endpointUrl, atp.Options.SourceGenerationContext.ChatBskyModerationGetMessageContextOutput!, cancellationToken, headers);
@@ -95,7 +95,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
         {
             var endpointUrl = UpdateActorAccess.ToString();
             var headers = new Dictionary<string, string>();
-            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);
+            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new UpdateActorAccessInput();
             inputItem.Actor = actor;
             inputItem.AllowAccess = allowAccess;

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -1115,15 +1115,15 @@ public partial class AppCommands
                 case "procedure":
                     sb.AppendLine($"            var endpointUrl = {item.ClassName}.ToString();");
                     sb.AppendLine($"            var headers = new Dictionary<string, string>();");
-                    if (item.Id.Contains("chat"))
+                    if (item.Id.Contains("moderation"))
+                    {
+                        sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
+                    }
+                    else if (item.Id.Contains("chat"))
                     {
                         sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);");
                     }
                     else if (item.Id.Contains("ozone"))
-                    {
-                        sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
-                    }
-                    else if (item.Id.Contains("atproto.moderation"))
                     {
                         sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
                     }
@@ -1219,15 +1219,15 @@ public partial class AppCommands
                     }
 
                     sb.AppendLine($"            var headers = new Dictionary<string, string>();");
-                    if (item.Id.Contains("chat"))
+                    if (item.Id.Contains("moderation"))
+                    {
+                        sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
+                    }
+                    else if (item.Id.Contains("chat"))
                     {
                         sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, Constants.BlueskyChatProxy);");
                     }
                     else if (item.Id.Contains("ozone"))
-                    {
-                        sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
-                    }
-                    else if (item.Id.Contains("atproto.moderation"))
                     {
                         sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
                     }


### PR DESCRIPTION
The Chat endpoints also need to use the Ozone proxy to properly work. I don't believe these are documented either in the bsky docs.