### PR TITLE
Add Union type checks for POSTs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "preLaunchTask": "build_ffsourcegen",
             "program": "${workspaceFolder}/tools/FFSourceGen/bin/Debug/net9.0/FFSourceGen.dll",
-            "args": [ "generate", "${workspaceFolder}/../atproto/lexicons", "-o", "${workspaceFolder}/src/FishyFlip/" ],
+            "args": [ "generate", "${workspaceFolder}/../fflexicons/bluesky-social-atproto/lexicons", "-o", "${workspaceFolder}/src/FishyFlip/" ],
             "cwd": "${workspaceFolder}/tools/FFSourceGen",
             "console": "internalConsole",
             "stopAtEntry": false

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
@@ -362,6 +362,16 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             var endpointUrl = UpdateSubjectStatus.ToString();
             var headers = new Dictionary<string, string>();
             var inputItem = new UpdateSubjectStatusInput();
+            switch (subject.Type)
+            {
+                case "com.atproto.admin.defs#repoRef":
+                case "com.atproto.repo.strongRef":
+                case "com.atproto.admin.defs#repoBlobRef":
+                    break;
+                default:
+                    atp.Options.Logger?.LogWarning($"Unknown subject type for union: " + subject.Type);
+                    break;
+            }
             inputItem.Subject = subject;
             inputItem.Takedown = takedown;
             inputItem.Deactivated = deactivated;

--- a/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
@@ -41,6 +41,15 @@ namespace FishyFlip.Lexicon.Com.Atproto.Moderation
             headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new CreateReportInput();
             inputItem.ReasonType = reasonType;
+            switch (subject.Type)
+            {
+                case "com.atproto.admin.defs#repoRef":
+                case "com.atproto.repo.strongRef":
+                    break;
+                default:
+                    atp.Options.Logger?.LogWarning($"Unknown subject type for union: " + subject.Type);
+                    break;
+            }
             inputItem.Subject = subject;
             inputItem.Reason = reason;
             return atp.Post<CreateReportInput, FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput?>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportInput!, atp.Options.SourceGenerationContext.ComAtprotoModerationCreateReportOutput!, inputItem, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
@@ -50,7 +50,40 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
             var headers = new Dictionary<string, string>();
             headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);
             var inputItem = new EmitEventInput();
+            switch (@event.Type)
+            {
+                case "tools.ozone.moderation.defs#modEventTakedown":
+                case "tools.ozone.moderation.defs#modEventAcknowledge":
+                case "tools.ozone.moderation.defs#modEventEscalate":
+                case "tools.ozone.moderation.defs#modEventComment":
+                case "tools.ozone.moderation.defs#modEventLabel":
+                case "tools.ozone.moderation.defs#modEventReport":
+                case "tools.ozone.moderation.defs#modEventMute":
+                case "tools.ozone.moderation.defs#modEventUnmute":
+                case "tools.ozone.moderation.defs#modEventMuteReporter":
+                case "tools.ozone.moderation.defs#modEventUnmuteReporter":
+                case "tools.ozone.moderation.defs#modEventReverseTakedown":
+                case "tools.ozone.moderation.defs#modEventResolveAppeal":
+                case "tools.ozone.moderation.defs#modEventEmail":
+                case "tools.ozone.moderation.defs#modEventTag":
+                case "tools.ozone.moderation.defs#accountEvent":
+                case "tools.ozone.moderation.defs#identityEvent":
+                case "tools.ozone.moderation.defs#recordEvent":
+                    break;
+                default:
+                    atp.Options.Logger?.LogWarning($"Unknown @event type for union: " + @event.Type);
+                    break;
+            }
             inputItem.Event = @event;
+            switch (subject.Type)
+            {
+                case "com.atproto.admin.defs#repoRef":
+                case "com.atproto.repo.strongRef":
+                    break;
+                default:
+                    atp.Options.Logger?.LogWarning($"Unknown subject type for union: " + subject.Type);
+                    break;
+            }
             inputItem.Subject = subject;
             inputItem.CreatedBy = createdBy;
             inputItem.SubjectBlobCids = subjectBlobCids;


### PR DESCRIPTION
Fixes #152 

This adds a type check for `union` lexicon objects, where if we know the values from the lexicon, we will check the `type` property and compare it to what it says it supports. If you use one that's not listed, it won't throw (since depending on what service you are using, that may still be valid) but it will log it as a warning to let you know the type you passed it is not in the Union, which should make checking for issues easier.