### PR TITLE
Make DID resolution cache thread-safe

### DIFF
--- a/src/FishyFlip/ATProtocol.cs
+++ b/src/FishyFlip/ATProtocol.cs
@@ -266,8 +266,7 @@ public sealed partial class ATProtocol : IDisposable
     /// <returns>String of Host URI if it could be resolved, null if it could not.</returns>
     public async Task<Result<string?>> ResolveATHandleHostAsync(ATHandle handle, CancellationToken? token = default)
     {
-        string? host = this.options.DidCache.FirstOrDefault(n => n.Key == handle.ToString()).Value;
-        if (!string.IsNullOrEmpty(host))
+        if (this.options.DidCache.TryGetValue(handle.ToString(), out var host) && !string.IsNullOrEmpty(host))
         {
             this.options.Logger?.LogDebug($"Resolved handle from cache: {handle} to {host}");
             return host;
@@ -344,8 +343,7 @@ public sealed partial class ATProtocol : IDisposable
     /// <returns>String of Host URI if it could be resolved, null if it could not.</returns>
     public async Task<Result<string?>> ResolveATDidHostAsync(ATDid did, CancellationToken? token = default)
     {
-        string? host = this.options.DidCache.FirstOrDefault(n => n.Key == did.ToString()).Value;
-        if (!string.IsNullOrEmpty(host))
+        if (this.options.DidCache.TryGetValue(did.ToString(), out var host) && !string.IsNullOrEmpty(host))
         {
             this.options.Logger?.LogDebug($"Resolved DID from cache: {did} to {host}");
             return host;

--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using FishyFlip.Tools.Json;
+using System.Collections.Concurrent;
 using System.Net;
 
 namespace FishyFlip;
@@ -78,7 +79,7 @@ public class ATProtocolOptions
     /// <summary>
     /// Gets the Did Cache.
     /// </summary>
-    internal Dictionary<string, string> DidCache { get; } = new Dictionary<string, string>();
+    internal ConcurrentDictionary<string, string> DidCache { get; } = new();
 
     /// <summary>
     /// Gets the source generation context.


### PR DESCRIPTION
Despite their apparent thread-safety (being respectively an `HttpClient` wrapper and an immutable object), `ATProtocol`/`ATProtocolOptions` actually contain a thread-unsafe mutable `Dictionary`.

Please note that applying an external lock before accessing the `ATProtocol` isn't a viable option, because such lock would span across `await`s and network operations.
On the other hand, using a separate `ATProtocol` for each thread would mean that the DID resolutions cannot be shared across threads.

This also fixes the O(N) lookups into such cache (`FirstOrDefault`)