### PR TITLE
Improve CarDecoder.DecodeCar(byte[]) performance

### DIFF
--- a/src/FishyFlip/Tools/CarDecoder.cs
+++ b/src/FishyFlip/Tools/CarDecoder.cs
@@ -25,6 +25,16 @@ public static class CarDecoder
     /// </summary>
     /// <param name="bytes">Byte Array.</param>
     /// <param name="progress">Fires when a car file is decoded.</param>
+    public static void DecodeCar(byte[] bytes, OnCarDecoded? progress = null)
+    {
+        DecodeCar(bytes.AsSpan(), progress);
+    }
+
+    /// <summary>
+    /// Decodes CAR ReadOnlySpan.
+    /// </summary>
+    /// <param name="bytes">Bytes to decode.</param>
+    /// <param name="progress">Fires when a car file is decoded.</param>
     public static void DecodeCar(ReadOnlySpan<byte> bytes, OnCarDecoded? progress = null)
     {
         int bytesLength = bytes.Length;

--- a/src/FishyFlip/Tools/CarDecoder.cs
+++ b/src/FishyFlip/Tools/CarDecoder.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 
+using System.Runtime.InteropServices;
+
 namespace FishyFlip.Tools;
 
 /// <summary>
@@ -23,7 +25,7 @@ public static class CarDecoder
     /// </summary>
     /// <param name="bytes">Byte Array.</param>
     /// <param name="progress">Fires when a car file is decoded.</param>
-    public static void DecodeCar(byte[] bytes, OnCarDecoded? progress = null)
+    public static void DecodeCar(ReadOnlySpan<byte> bytes, OnCarDecoded? progress = null)
     {
         int bytesLength = bytes.Length;
         var header = DecodeReader(bytes);
@@ -41,12 +43,12 @@ public static class CarDecoder
             start += body.Length;
 
             var cidBytes = bytes[start..(start + ATCidV1BytesLength)];
-            var cid = Cid.Read(cidBytes);
+            var cid = Cid.Read(cidBytes.ToArray());
 
             start += ATCidV1BytesLength;
             var bs = bytes[start..(start + body.Value - ATCidV1BytesLength)];
             start += body.Value - ATCidV1BytesLength;
-            progress?.Invoke(new CarProgressStatusEvent(cid, bs));
+            progress?.Invoke(new CarProgressStatusEvent(cid, bs.ToArray()));
         }
     }
 
@@ -121,33 +123,32 @@ public static class CarDecoder
             }
         }
 
-        return new DecodedBlock(Decode(a), a.Count);
+#if NET5_OR_GREATER
+        return new DecodedBlock(Decode(CollectionsMarshal.AsSpan(a)), a.Count);
+#else
+        return new DecodedBlock(Decode(a.ToArray()), a.Count);
+#endif
     }
 
-    private static DecodedBlock DecodeReader(byte[] bytes)
+    private static DecodedBlock DecodeReader(ReadOnlySpan<byte> bytes)
     {
-        var a = new List<byte>();
-
-        int i = 0;
-        while (true)
+        for (int i = 0; i < bytes.Length; i++)
         {
             byte b = bytes[i];
-
-            i++;
-            a.Add(b);
             if ((b & 0x80) == 0)
             {
-                break;
+                var a = bytes.Slice(0, i + 1);
+                return new DecodedBlock(Decode(a), a.Length);
             }
         }
 
-        return new DecodedBlock(Decode(a), a.Count);
+        throw new InvalidDataException("Incomplete block.");
     }
 
-    private static int Decode(List<byte> b)
+    private static int Decode(ReadOnlySpan<byte> b)
     {
         int r = 0;
-        for (int i = 0; i < b.Count; i++)
+        for (int i = 0; i < b.Length; i++)
         {
             int e = b[i];
             r = r + ((e & 0x7F) << (i * 7));


### PR DESCRIPTION
Reading a 3.71 MB CAR file (including ATObject parsing), 10x times, net9.0 Release

Original implementation
  01:20.61

This PR
  00:02.43