### PR TITLE
Fix OAuth Serializer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,17 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "OAuth Start",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build_oauth",
+            "program": "${workspaceFolder}/samples/OAuth/bin/Debug/net9.0/OAuth.dll",
+            "args": [ "start" ],
+            "cwd": "${workspaceFolder}/samples/OAuth",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             "name": "FFSourceGen",
             "type": "coreclr",
             "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,18 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "build_oauth",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/samples/OAuth/OAuth.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "build_bskycli",
             "command": "dotnet",
             "type": "process",

--- a/src/FishyFlip/OidcClient/Infrastructure/LogSerializer.cs
+++ b/src/FishyFlip/OidcClient/Infrastructure/LogSerializer.cs
@@ -60,7 +60,7 @@ namespace IdentityModel.OidcClient.Infrastructure
         private static string Serialize<T>(T logObject)
         {
             return Enabled ?
-                JsonSerializer.Serialize(logObject, (JsonTypeInfo<T>)SourceGenerationContext.Default.GetTypeInfo(typeof(T))!) :
+                JsonSerializer.Serialize(logObject, (JsonTypeInfo<T>)IdentityModel.OidcClient.OidcClientSourceGenerationContext.Default.GetTypeInfo(typeof(T))!) :
                 "Logging has been disabled";
 		}
     }

--- a/src/FishyFlip/OidcClient/OidcClientSourceGenerationContext.cs
+++ b/src/FishyFlip/OidcClient/OidcClientSourceGenerationContext.cs
@@ -1,0 +1,25 @@
+// <copyright file="OidcClientSourceGenerationContext.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IdentityModel.OidcClient
+{
+    /// <summary>
+    /// Source generation context for OidcClient.
+    /// </summary>
+    [JsonSourceGenerationOptions(
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+        GenerationMode = JsonSourceGenerationMode.Metadata,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(AuthorizeState))]
+    [JsonSerializable(typeof(Dictionary<string, JsonElement>))]
+    [JsonSerializable(typeof(OidcClientOptions))]
+    internal partial class OidcClientSourceGenerationContext : JsonSerializerContext
+    {
+    }
+}


### PR DESCRIPTION
The OAuth Serializer was broken, since it used the base SourceGenerationContext for JSON, which didn't have the expected objects. This would break OAuth unless you disabled logging.