### PR TITLE
Use order-by to enforce order of operation for files

### DIFF
--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -110,7 +110,7 @@ public partial class AppCommands
 
     private async Task GenerateClasses(string lexiconPath)
     {
-        var files = Directory.EnumerateFiles(lexiconPath, "*.json", SearchOption.AllDirectories).ToList();
+        var files = Directory.EnumerateFiles(lexiconPath, "*.json", SearchOption.AllDirectories).OrderBy(n => n).ToList();
         Console.WriteLine($"Found {files.Count()} files.");
 
         var defs = files.Where(n => n.Contains("defs.json")).ToList();


### PR DESCRIPTION
Depending on which platform FFSourceGen was run, the bindings could be different since files could be processed in different orders. This enforces the order.