### PR TITLE
Add missing Firehose Frames

### DIFF
--- a/samples/Firehose/Program.cs
+++ b/samples/Firehose/Program.cs
@@ -33,7 +33,7 @@ atWebProtocol.OnSubscribedRepoMessage += (sender, args) =>
 
 await atWebProtocol.StartSubscribeReposAsync();
 
-var key = Console.ReadKey();
+var key = Console.Read();
 
 await atWebProtocol.StopSubscriptionAsync();
 

--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -253,6 +253,12 @@ public sealed class ATWebSocketProtocol : IDisposable
                     case "#migrate":
                         message.Migrate = new FrameMigrate(objects[1]);
                         break;
+                    case "#account":
+                        message.Account = new FrameAccount(objects[1]);
+                        break;
+                    case "#identity":
+                        message.Identity = new FrameIdentity(objects[1]);
+                        break;
                     default:
                         this.logger?.LogDebug($"Unknown Frame: {objects[1].ToJSONString()}");
                         break;

--- a/src/FishyFlip/Models/FrameAccount.cs
+++ b/src/FishyFlip/Models/FrameAccount.cs
@@ -1,0 +1,43 @@
+// <copyright file="FrameAccount.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Frame Account.
+/// </summary>
+public class FrameAccount
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrameAccount"/> class.
+    /// </summary>
+    /// <param name="obj">The CBOR object containing the account information.</param>
+    public FrameAccount(CBORObject obj)
+    {
+        this.Seq = obj["seq"].AsInt64Value();
+        this.Did = obj["did"] is not null ? ATDid.Create(obj["did"].AsString()) : null;
+        this.Time = obj["time"]?.ToDateTime();
+        this.Active = obj["active"]?.AsBoolean() ?? false;
+    }
+
+    /// <summary>
+    /// Gets the did.
+    /// </summary>
+    public ATDid? Did { get; }
+
+    /// <summary>
+    /// Gets the sequence.
+    /// </summary>
+    public long Seq { get; }
+
+    /// <summary>
+    /// Gets the date time of the frame.
+    /// </summary>
+    public DateTime? Time { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the account is active.
+    /// </summary>
+    public bool Active { get; }
+}

--- a/src/FishyFlip/Models/FrameIdentity.cs
+++ b/src/FishyFlip/Models/FrameIdentity.cs
@@ -1,0 +1,43 @@
+// <copyright file="FrameIdentity.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Frame Identity.
+/// </summary>
+public class FrameIdentity
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrameIdentity"/> class.
+    /// </
+    /// <param name="obj">The CBOR object containing the identity information.</param>
+    public FrameIdentity(CBORObject obj)
+    {
+        this.Seq = obj["seq"].AsInt64Value();
+        this.Did = obj["did"] is not null ? ATDid.Create(obj["did"].AsString()) : null;
+        this.Time = obj["time"]?.ToDateTime();
+        this.Handle = obj["handle"] is not null ? ATHandle.Create(obj["handle"].AsString()) : null;
+    }
+
+    /// <summary>
+    /// Gets the did.
+    /// </summary>
+    public ATDid? Did { get; }
+
+    /// <summary>
+    /// Gets the sequence.
+    /// </summary>
+    public long Seq { get; }
+
+    /// <summary>
+    /// Gets the date time of the frame.
+    /// </summary>
+    public DateTime? Time { get; }
+
+    /// <summary>
+    /// Gets the handle.
+    /// </summary>
+    public ATHandle? Handle { get; }
+}

--- a/src/FishyFlip/Models/SubscribeRepoMessage.cs
+++ b/src/FishyFlip/Models/SubscribeRepoMessage.cs
@@ -60,6 +60,16 @@ public class SubscribeRepoMessage
     public FrameTombstone? Tombstone { get; internal set; }
 
     /// <summary>
+    /// Gets the account of the message.
+    /// </summary>
+    public FrameAccount? Account { get; internal set; }
+
+    /// <summary>
+    /// Gets the identity of the message.
+    /// </summary>
+    public FrameIdentity? Identity { get; internal set; }
+
+    /// <summary>
     /// Gets the list of nodes in the message.
     /// </summary>
     public List<FrameNode> Nodes { get; } = new List<FrameNode>();


### PR DESCRIPTION
The Firehose was missing events for `#account` and `#identity` so you could not check when accounts were created and when handles were added. This fixes it.