### PR TITLE
Address WebSocket Byte Array handling

### DIFF
--- a/src/FishyFlip/Models/FrameHeader.cs
+++ b/src/FishyFlip/Models/FrameHeader.cs
@@ -15,6 +15,11 @@ public class FrameHeader
     /// <param name="obj">The CBOR Object.</param>
     public FrameHeader(CBORObject obj)
     {
+        if (obj.Count <= 0)
+        {
+            return;
+        }
+
         this.Operation = (FrameHeaderOperation)(obj["op"]?.AsInt32() ?? 0);
         this.Type = obj["t"]?.AsString();
     }


### PR DESCRIPTION
Fixes #7 

The byte array handling for the WebSocket connection would lead to byte array objects that were either empty or not complete, leading to exceptions in Peter.CBOR. It wasn't that libraries fault, as far as I can tell it was all me.

This could be enhanced further to reduce the amount of byte array handling and switching it to spans all together, but I need to make sure it works right with .NET Standard first. This should be a good start though.