### PR TITLE
Throw Firehose message handling back off-thread

### DIFF
--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -323,12 +323,12 @@ public sealed class ATWebSocketProtocol : IDisposable
                     switch (result.MessageType)
                     {
                         case WebSocketMessageType.Binary:
-                            this.HandleMessage(completeMessage);
+                            Task.Run(() => this.HandleMessage(completeMessage)).FireAndForgetSafeAsync(this.logger);
                             break;
 
                         case WebSocketMessageType.Text:
                             string textMessage = Encoding.UTF8.GetString(completeMessage);
-                            this.HandleTextMessage(textMessage);
+                            Task.Run(() => this.HandleTextMessage(textMessage)).FireAndForgetSafeAsync(this.logger);
                             break;
                     }
 

--- a/src/FishyFlip/Models/FrameError.cs
+++ b/src/FishyFlip/Models/FrameError.cs
@@ -15,8 +15,14 @@ public class FrameError
     /// <param name="obj">The CBOR object containing the atError information.</param>
     public FrameError(CBORObject obj)
     {
-        this.Error = obj["atError"].AsString();
-        this.Message = obj["message"].AsString();
+        try
+        {
+            this.Error = obj["atError"].AsString();
+            this.Message = obj["message"].AsString();
+        }
+        catch
+        {
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
I had removed the FireandForgetSafeAsync from the HandleMessage code, thinking it wouldn't be needed due to the parsing improvements. Turns out that parsing a big message gives it just enough of a hang to get a FrameError for not handling it fast enough. Throwing the byte array back off-thread and letting it process on its own time seems to fix it, but it could probably be improved. 