### PR TITLE
Switch Firehose parsing to use Pipes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.IO.Pipelines" Version="9.0.1" />
+    <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Memory.Data" Version="9.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="Drastic.Utilities" Version="1.0.10" />

--- a/samples/Firehose/Firehose.csproj
+++ b/samples/Firehose/Firehose.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -2,6 +2,9 @@
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 
+using System.Buffers;
+using System.IO.Pipelines;
+
 namespace FishyFlip;
 
 /// <summary>
@@ -9,8 +12,7 @@ namespace FishyFlip;
 /// </summary>
 public sealed class ATWebSocketProtocol : IDisposable
 {
-    private const int ReceiveBufferSize = 32768;
-    private ClientWebSocket client;
+    private WebSocketWrapper webSocketWrapper;
     private bool disposedValue;
     private ILogger? logger;
     private Uri instanceUri;
@@ -23,7 +25,8 @@ public sealed class ATWebSocketProtocol : IDisposable
     {
         this.logger = options.Logger;
         this.instanceUri = options.Url;
-        this.client = new ClientWebSocket();
+        this.webSocketWrapper = new WebSocketWrapper(this.logger);
+        this.webSocketWrapper.OnMessageReceived += this.OnMessageReceived;
     }
 
     /// <summary>
@@ -53,7 +56,7 @@ public sealed class ATWebSocketProtocol : IDisposable
     /// <summary>
     /// Gets a value indicating whether ATProtocol is connected.
     /// </summary>
-    public bool IsConnected => this.client.State == WebSocketState.Open;
+    public bool IsConnected => this.webSocketWrapper.IsConnected;
 
     /// <summary>
     /// Connect to the BlueSky instance via a WebSocket connection.
@@ -63,21 +66,15 @@ public sealed class ATWebSocketProtocol : IDisposable
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task ConnectAsync(string connection, CancellationToken? token = default)
     {
-        if (this.client.State == WebSocketState.Open)
+        if (this.IsConnected)
         {
             return;
         }
 
-        if (this.client.State == WebSocketState.Aborted || this.client.State == WebSocketState.Closed)
-        {
-            this.client = new ClientWebSocket();
-        }
-
         var endToken = token ?? CancellationToken.None;
-        await this.client.ConnectAsync(new Uri($"wss://{this.instanceUri.Host}{connection}"), endToken);
+        await this.webSocketWrapper.ConnectAsync(new Uri($"wss://{this.instanceUri.Host}{connection}"), endToken);
         this.logger?.LogInformation($"WSS: Connected to {this.instanceUri}");
-        this.ReceiveMessages(this.client, endToken).FireAndForgetSafeAsync(this.logger);
-        this.OnConnectionUpdated?.Invoke(this, new SubscriptionConnectionStatusEventArgs(this.client.State));
+        this.OnConnectionUpdated?.Invoke(this, new SubscriptionConnectionStatusEventArgs(this.webSocketWrapper.State));
     }
 
     /// <summary>
@@ -93,14 +90,14 @@ public sealed class ATWebSocketProtocol : IDisposable
         this.logger?.LogInformation($"WSS: Disconnecting");
         try
         {
-            await this.client.CloseAsync(status, disconnectReason, endToken);
+            await this.webSocketWrapper.CloseAsync(endToken);
         }
         catch (Exception ex)
         {
             this.logger?.LogError(ex, "Failed to Close WebSocket connection.");
         }
 
-        this.OnConnectionUpdated?.Invoke(this, new SubscriptionConnectionStatusEventArgs(this.client.State));
+        this.OnConnectionUpdated?.Invoke(this, new SubscriptionConnectionStatusEventArgs(this.webSocketWrapper.State));
     }
 
     /// <summary>
@@ -160,15 +157,16 @@ public sealed class ATWebSocketProtocol : IDisposable
         {
             if (disposing)
             {
-                this.client.Dispose();
+                // this.webSocketWrapper.DisposeAsync();
             }
 
             this.disposedValue = true;
         }
     }
 
-    private void HandleMessage(byte[] byteArray)
+    private void HandleMessage(ReadOnlySpan<byte> span)
     {
+        byte[] byteArray = span.ToArray();
         if (byteArray.Length == 0)
         {
             this.logger?.LogDebug("WSS: ATError reading message. Empty byte array.");
@@ -199,7 +197,6 @@ public sealed class ATWebSocketProtocol : IDisposable
 
         var frameHeader = new FrameHeader(objects[0]);
 
-        // this.logger?.LogDebug($"FrameHeader: {objects[0].ToJSONString()}");
         message.Header = frameHeader;
 
         switch (frameHeader.Operation)
@@ -212,8 +209,6 @@ public sealed class ATWebSocketProtocol : IDisposable
                 {
                     case "#commit":
                         var frameCommit = new FrameCommit(objects[1], this.logger);
-
-                        // this.logger?.LogDebug($"FrameBody: {objects[1].ToJSONString()}");
                         message.Commit = frameCommit;
                         if (frameCommit.Blocks is null)
                         {
@@ -283,90 +278,136 @@ public sealed class ATWebSocketProtocol : IDisposable
         this.OnSubscribedRepoMessage?.Invoke(this, new SubscribedRepoEventArgs(message));
     }
 
-    private async Task ReceiveMessages(ClientWebSocket webSocket, CancellationToken token)
+    private Task OnMessageReceived(ReadOnlySequence<byte> message)
     {
-        const int InitialBufferSize = 4096;
-        using var memoryStream = new MemoryStream();
+        var newMessage = message.ToArray();
+        Task.Run(() => this.HandleMessage(newMessage)).FireAndForgetSafeAsync(this.logger);
+        return Task.CompletedTask;
+    }
 
-        while (webSocket.State == WebSocketState.Open)
+    private class WebSocketWrapper : IAsyncDisposable
+    {
+        private readonly ClientWebSocket webSocket;
+        private readonly Pipe pipe;
+        private readonly CancellationTokenSource cts;
+        private readonly ILogger? logger;
+        private Task? receiveTask;
+
+        public WebSocketWrapper(ILogger? logger)
+        {
+            this.webSocket = new ClientWebSocket();
+            this.pipe = new Pipe();
+            this.cts = new CancellationTokenSource();
+            this.logger = logger;
+        }
+
+        public delegate Task MessageReceivedHandler(ReadOnlySequence<byte> message);
+
+        public event MessageReceivedHandler? OnMessageReceived;
+
+        public WebSocketState State => this.webSocket.State;
+
+        public bool IsConnected => this.webSocket.State == WebSocketState.Open;
+
+        public async Task ConnectAsync(Uri uri, CancellationToken cancellationToken = default)
+        {
+            if (this.webSocket.State == WebSocketState.Open)
+            {
+                return;
+            }
+
+            this.logger?.LogInformation("WSS: Connecting to WebSocket.");
+            await this.webSocket.ConnectAsync(uri, cancellationToken);
+            this.receiveTask = this.StartReceiveLoop();
+        }
+
+        public async Task CloseAsync(CancellationToken cancellationToken = default)
+        {
+            this.logger?.LogInformation("WSS: Closing WebSocket connection.");
+            await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", cancellationToken);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            this.cts.Cancel();
+
+            try
+            {
+                if (this.webSocket.State == WebSocketState.Open)
+                {
+                    this.logger?.LogInformation("WSS: Closing WebSocket connection.");
+                    await this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+                }
+            }
+            finally
+            {
+                this.webSocket.Dispose();
+                this.cts.Dispose();
+                this.receiveTask?.Dispose();
+            }
+        }
+
+        private async Task StartReceiveLoop()
         {
             try
             {
-                var messageBuffer = new byte[InitialBufferSize];
-                WebSocketReceiveResult result;
-
-                // Keep receiving until we get a complete message
-                do
+                while (!this.cts.Token.IsCancellationRequested && this.webSocket.State == WebSocketState.Open)
                 {
+                    var memory = this.pipe.Writer.GetMemory(8192);
 #if NETSTANDARD
-                    result = await webSocket.ReceiveAsync(new ArraySegment<byte>(messageBuffer), token);
+                    var arraySegment = new ArraySegment<byte>(memory.Span.ToArray());
+                    var result = await this.webSocket.ReceiveAsync(
+                        arraySegment, this.cts.Token);
 #else
-                    result = await webSocket.ReceiveAsync(messageBuffer, token);
+                    var result = await this.webSocket.ReceiveAsync(
+                        memory, this.cts.Token);
 #endif
 
                     if (result.MessageType == WebSocketMessageType.Close)
                     {
-                        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", token);
                         break;
                     }
 
-                    // Write received data to memory stream
-                    await memoryStream.WriteAsync(messageBuffer, 0, result.Count, token);
-                }
-                while (!result.EndOfMessage);
+                    this.pipe.Writer.Advance(result.Count);
 
-                // Process the complete message
-                if (memoryStream.Length > 0)
-                {
-                    byte[] completeMessage = memoryStream.ToArray();
-
-                    switch (result.MessageType)
+                    if (result.EndOfMessage)
                     {
-                        case WebSocketMessageType.Binary:
-                            Task.Run(() => this.HandleMessage(completeMessage)).FireAndForgetSafeAsync(this.logger);
-                            break;
-
-                        case WebSocketMessageType.Text:
-                            string textMessage = Encoding.UTF8.GetString(completeMessage);
-                            Task.Run(() => this.HandleTextMessage(textMessage)).FireAndForgetSafeAsync(this.logger);
-                            break;
+                        await this.pipe.Writer.FlushAsync(this.cts.Token);
+                        await this.ProcessMessageAsync();
                     }
-
-                    // Reset stream for next message
-                    memoryStream.SetLength(0);
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException ocx)
             {
-                this.logger?.LogDebug("WSS: Operation Canceled.");
-                break;
+                this.logger?.LogInformation(ocx, "WSS: Operation Cancelled.");
             }
-            catch (WebSocketException wsEx)
+            catch (Exception ex)
             {
-                this.logger?.LogError(wsEx, "WSS: WebSocket error occurred.");
-                break;
+                this.logger?.LogError(ex, "WSS: Error in Receive Loop.");
+                throw;
             }
-            catch (Exception e)
+            finally
             {
-                this.logger?.LogError(e, "WSS: Error receiving message.");
-
-                await Task.Delay(1000, token);
+                await this.pipe.Writer.CompleteAsync();
             }
         }
 
-        // Connection status update
-        this.OnConnectionUpdated?.Invoke(this, new SubscriptionConnectionStatusEventArgs(webSocket.State));
-    }
+        private async Task ProcessMessageAsync()
+        {
+            ReadResult result = await this.pipe.Reader.ReadAsync(this.cts.Token);
+            ReadOnlySequence<byte> buffer = result.Buffer;
 
-    private void HandleTextMessage(string message)
-    {
-        try
-        {
-            this.logger?.LogDebug($"WSS: Received text message: {message}");
-        }
-        catch (Exception ex)
-        {
-            this.logger?.LogError(ex, "WSS: Error handling text message");
+            try
+            {
+                if (this.OnMessageReceived != null)
+                {
+                    await this.OnMessageReceived(buffer);
+                }
+            }
+            finally
+            {
+                this.pipe.Reader.AdvanceTo(buffer.End);
+            }
         }
     }
 }

--- a/src/FishyFlip/FishyFlip.csproj
+++ b/src/FishyFlip/FishyFlip.csproj
@@ -24,14 +24,20 @@
 			<PrivateAssets>All</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="System.IO.Pipelines" />
 		<PackageReference Include="ZstdSharp.Port" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="System.Memory" />
 		<PackageReference Include="System.Memory.Data" />
 		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 	<ItemGroup Condition=" ('$(IsPackable)' == 'true') or ('$(PackAsTool)' == 'true') ">
 		<None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" Visible="false" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	  <PackageReference Include="System.Memory" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+	  <PackageReference Include="System.Memory" />
 	</ItemGroup>
 </Project>

--- a/src/FishyFlip/Models/FrameError.cs
+++ b/src/FishyFlip/Models/FrameError.cs
@@ -15,14 +15,8 @@ public class FrameError
     /// <param name="obj">The CBOR object containing the atError information.</param>
     public FrameError(CBORObject obj)
     {
-        try
-        {
-            this.Error = obj["atError"].AsString();
-            this.Message = obj["message"].AsString();
-        }
-        catch
-        {
-        }
+        this.Error = obj["error"].AsString();
+        this.Message = obj["message"].AsString();
     }
 
     /// <summary>


### PR DESCRIPTION
The Firehose WebSocket parsing was too slow, causing FrameError events to be thrown, saying the consumer was too slow. That's because it's sending new events, and they're blocked due to the processing.

This tries to fix that by wrapping the underlying WebSocket Client, having it only deal with managing getting the complete message through a memory span and pipe, and throwing it out as a new event. This should dramatically improve the speed of processing. I'm still validating on if this is enough of an improvement though to fully prevent this error from being thrown, although it could also happen if your connection is slow or if the firehose itself is having problems processing. 