### PR TITLE
Add LoginHint support for OAuth

### DIFF
--- a/src/FishyFlip/OAuth2SessionManager.cs
+++ b/src/FishyFlip/OAuth2SessionManager.cs
@@ -109,10 +109,11 @@ internal class OAuth2SessionManager : ISessionManager
     /// <param name="clientId">ClientID, must be a URL.</param>
     /// <param name="redirectUrl">RedirectUrl.</param>
     /// <param name="scopes">ATProtocol Scopes.</param>
+    /// <param name="loginHint">LoginHint.</param>
     /// <param name="instanceUrl">InstanceUrl, must be a URL. If null, uses https://bsky.social.</param>
     /// <param name="cancellationToken">Cancellation Token.</param>
     /// <returns>Authorization URL to call.</returns>
-    public async Task<string> StartAuthorizationAsync(string clientId, string redirectUrl, IEnumerable<string> scopes, string? instanceUrl = default, CancellationToken cancellationToken = default)
+    public async Task<string> StartAuthorizationAsync(string clientId, string redirectUrl, IEnumerable<string> scopes, string? loginHint = default,  string? instanceUrl = default, CancellationToken cancellationToken = default)
     {
         instanceUrl ??= Constants.Urls.ATProtoServer.SocialApi;
         var options = new OidcClientOptions
@@ -122,6 +123,7 @@ internal class OAuth2SessionManager : ISessionManager
             Scope = string.Join(" ", scopes),
             RedirectUri = redirectUrl,
             LoadProfile = false,
+            LoginHint = loginHint,
         };
         this.proofKey = JsonWebKeys.CreateRsaJson();
         options.ConfigureDPoP(this.proofKey);

--- a/src/FishyFlip/OidcClient/AuthorizeClient.cs
+++ b/src/FishyFlip/OidcClient/AuthorizeClient.cs
@@ -139,7 +139,7 @@ namespace IdentityModel.OidcClient
             {
                 Address = _options.ProviderInformation.PushedAuthorizationRequestEndpoint,
                 ClientId = _options.ClientId,
-                
+                LoginHint = _options.LoginHint,
                 ClientSecret = _options.ClientSecret,
                 ClientAssertion = await _options.GetClientAssertionAsync(),
                 Parameters = CreateAuthorizeParameters(state, codeChallenge, frontChannelParameters),

--- a/src/FishyFlip/OidcClient/OidcClientOptions.cs
+++ b/src/FishyFlip/OidcClient/OidcClientOptions.cs
@@ -63,6 +63,11 @@ namespace IdentityModel.OidcClient
         public string ClientSecret { get; set; }
 
         /// <summary>
+        /// Gets or sets the login_hint protocol parameter.
+        /// </summary>
+        public string LoginHint { get; set; }
+
+        /// <summary>
         /// Gets or sets the client assertion (if needed).
         /// </summary>
         /// <value>


### PR DESCRIPTION
Adds new GenerateOAuth2AuthenticationUrlAsync for passing in an ATIdentifier. If added, it will set the LoginHint parameter for the generated OAuth URL, auto-filling the users handle into the form.