### PR TITLE
Update OAuth/Password Methods

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
             "request": "launch",
             "preLaunchTask": "build_oauth",
             "program": "${workspaceFolder}/samples/OAuth/bin/Debug/net9.0/OAuth.dll",
-            "args": [ "start" ],
+            "args": [ "start", "-id", "drasticactions.dev" ],
             "cwd": "${workspaceFolder}/samples/OAuth",
             "console": "internalConsole",
             "stopAtEntry": false

--- a/src/FishyFlip/Models/ATError.cs
+++ b/src/FishyFlip/Models/ATError.cs
@@ -29,6 +29,21 @@ public class ATError
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="ATError"/> class.
+    /// </summary>
+    /// <param name="exception">The exception.</param>
+    /// <returns>ATError.</returns>
+    public ATError(Exception exception)
+    {
+        this.StatusCode = 500;
+        this.Detail = new ErrorDetail()
+        {
+            Message = exception.Message,
+            StackTrace = exception.StackTrace,
+        };
+    }
+
+    /// <summary>
     /// Gets or sets the status code.
     /// </summary>
     [JsonPropertyName("statuscode")]

--- a/src/FishyFlip/Models/ErrorDetail.cs
+++ b/src/FishyFlip/Models/ErrorDetail.cs
@@ -40,6 +40,11 @@ public class ErrorDetail
     public string? Message { get; set; }
 
     /// <summary>
+    /// Gets or sets the atError stack trace.
+    /// </summary>
+    public string? StackTrace { get; set; }
+
+    /// <summary>
     /// ToString override.
     /// </summary>
     /// <returns>String.</returns>


### PR DESCRIPTION
This makes changes to the OAuth/Password methods to wrap them in `Return` objects. The original methods are still there, but they are listed as obsolete.

It also updates the `ATIdentifier` OAuth method to resolve the PDS so it can correctly go to the right users account. 