### PR TITLE
Make SessionManager public

### DIFF
--- a/src/FishyFlip/ATProtocol.cs
+++ b/src/FishyFlip/ATProtocol.cs
@@ -93,13 +93,13 @@ public sealed partial class ATProtocol : IDisposable
     };
 
     /// <summary>
-    /// Gets or sets the internal session manager.
+    /// Gets the session manager.
     /// </summary>
-    internal ISessionManager SessionManager
+    public ISessionManager SessionManager
     {
         get => this.sessionManager;
 
-        set
+        internal set
         {
             this.sessionManager.SessionUpdated -= this.OnSessionUpdated;
             this.sessionManager.Dispose();

--- a/src/FishyFlip/ISessionManager.cs
+++ b/src/FishyFlip/ISessionManager.cs
@@ -12,7 +12,7 @@ namespace FishyFlip;
 /// <summary>
 /// Manage ATProtocol sessions.
 /// </summary>
-internal interface ISessionManager : IDisposable
+public interface ISessionManager : IDisposable
 {
     /// <summary>
     /// Fires when a session is updated.


### PR DESCRIPTION
If you tried generating bindings for use outside of this codebase from FFSourceGen, you would need to handle SessionManager yourself by checking the available managers since this was internal. Now it's public, but it's internally set since I only want to handle the two I've written. I may change that for mocks in the future, I'll need to think about it more.