### PR TITLE
Add type back to Firehose CBOR

### DIFF
--- a/samples/Firehose/Program.cs
+++ b/samples/Firehose/Program.cs
@@ -53,6 +53,11 @@ atWebProtocol.OnMessageReceived += (sender, e) =>
     log.LogInformation($"Byte Message: {DateTime.UtcNow.Ticks}");
 };
 
+atWebProtocol.OnRecordReceived += (sender, e) =>
+{
+    log.LogInformation($"Record: {e.Record?.Type}");
+};
+
 await atWebProtocol.StartSubscribeReposAsync();
 
 var key = Console.Read();

--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -235,7 +235,7 @@ public sealed class ATWebSocketProtocol : IDisposable
                             {
                                 var type = blockObj["$type"].AsString();
                                 message.Record = blockObj.ToATObject(this.customConverters);
-
+                                message.Record!.Type = type;
                                 this.OnRecordReceived?.Invoke(this, new RecordMessageReceivedEventArgs(frameCommit, message.Record));
                             }
                             else if (blockObj["sig"] is not null)


### PR DESCRIPTION
The $type was being stripped from the Firehose created CBOR Objects. This adds it back by setting it in the message generation, although I need to see why it's leaving when it should be set elsewhere...