### PR TITLE
Implement SubscribeLabels and add Cursor support

### DIFF
--- a/samples/Firehose/Program.cs
+++ b/samples/Firehose/Program.cs
@@ -68,7 +68,6 @@ atWebProtocol.OnRecordReceived += (sender, e) =>
     log.LogInformation($"Record: {e.Record?.Type}");
 };
 
-await atWebProtocol.StartSubscribeReposAsync();
 await atLabelWebProtocol.StartSubscribeLabelsAsync();
 
 var key = Console.Read();

--- a/samples/Firehose/Program.cs
+++ b/samples/Firehose/Program.cs
@@ -68,7 +68,7 @@ atWebProtocol.OnRecordReceived += (sender, e) =>
     log.LogInformation($"Record: {e.Record?.Type}");
 };
 
-await atLabelWebProtocol.StartSubscribeLabelsAsync();
+await atLabelWebProtocol.StartSubscribeLabelsAsync(0);
 
 var key = Console.Read();
 

--- a/samples/Firehose/Program.cs
+++ b/samples/Firehose/Program.cs
@@ -34,6 +34,11 @@ var atWebProtocolBuilder = new ATWebSocketProtocolBuilder()
     .WithLogger(debugLog.CreateLogger("FishyFlipDebug"));
 var atWebProtocol = atWebProtocolBuilder.Build();
 
+var atLabelWebProtocolBuilder = new ATWebSocketProtocolBuilder()
+    .WithInstanceUrl(new Uri("https://mod.bsky.app"))
+    .WithLogger(debugLog.CreateLogger("FishyFlipDebug"));
+var atLabelWebProtocol = atLabelWebProtocolBuilder.Build();
+
 var atProtocolBuilder = new ATProtocolBuilder()
     .WithLogger(debugLog.CreateLogger("FishyFlipDebug"));
 var atProtocol = atProtocolBuilder.Build();
@@ -44,6 +49,11 @@ atWebProtocol.OnConnectionUpdated += (sender, e) =>
 };
 
 atWebProtocol.OnSubscribedRepoMessage += (sender, e) =>
+{
+    log.LogInformation($"Message: {DateTime.UtcNow.Ticks}");
+};
+
+atLabelWebProtocol.OnSubscribedLabelMessage += (sender, e) =>
 {
     log.LogInformation($"Message: {DateTime.UtcNow.Ticks}");
 };
@@ -59,6 +69,7 @@ atWebProtocol.OnRecordReceived += (sender, e) =>
 };
 
 await atWebProtocol.StartSubscribeReposAsync();
+await atLabelWebProtocol.StartSubscribeLabelsAsync();
 
 var key = Console.Read();
 

--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -146,7 +146,7 @@ public sealed class ATWebSocketProtocol : IDisposable
     public Task StartSubscribeLabelsAsync(long? cursor = default, CancellationToken? token = default)
     {
         this.subscribedLabels = true;
-        var endPoint = "/xrpc/com.atproto.sync.subscribeLabels";
+        var endPoint = "/xrpc/com.atproto.label.subscribeLabels";
         if (cursor is not null)
         {
             endPoint += $"?cursor={cursor}";

--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -123,20 +123,36 @@ public sealed class ATWebSocketProtocol : IDisposable
     /// <summary>
     /// Start the ATProtocol SubscribeRepos sync session.
     /// </summary>
+    /// <param name="cursor">The last known event seq number to backfill from.</param>
     /// <param name="token">Cancellation Token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task StartSubscribeReposAsync(CancellationToken? token = default)
-        => this.ConnectAsync("/xrpc/com.atproto.sync.subscribeRepos", token);
+    public Task StartSubscribeReposAsync(int? cursor = default, CancellationToken? token = default)
+    {
+        var endPoint = "/xrpc/com.atproto.sync.subscribeRepos";
+        if (cursor is not null)
+        {
+            endPoint += $"?cursor={cursor}";
+        }
+
+        return this.ConnectAsync(endPoint, token);
+    }
 
     /// <summary>
     /// Start the ATProtocol SubscribeRepos sync session.
     /// </summary>
+    /// <param name="cursor">The last known event seq number to backfill from.</param>
     /// <param name="token">Cancellation Token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task StartSubscribeLabelsAsync(CancellationToken? token = default)
+    public Task StartSubscribeLabelsAsync(int? cursor = default, CancellationToken? token = default)
     {
         this.subscribedLabels = true;
-        return this.ConnectAsync("/xrpc/com.atproto.sync.subscribeLabels", token);
+        var endPoint = "/xrpc/com.atproto.sync.subscribeLabels";
+        if (cursor is not null)
+        {
+            endPoint += $"?cursor={cursor}";
+        }
+
+        return this.ConnectAsync(endPoint, token);
     }
 
     /// <summary>

--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -126,7 +126,7 @@ public sealed class ATWebSocketProtocol : IDisposable
     /// <param name="cursor">The last known event seq number to backfill from.</param>
     /// <param name="token">Cancellation Token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task StartSubscribeReposAsync(int? cursor = default, CancellationToken? token = default)
+    public Task StartSubscribeReposAsync(long? cursor = default, CancellationToken? token = default)
     {
         var endPoint = "/xrpc/com.atproto.sync.subscribeRepos";
         if (cursor is not null)
@@ -143,7 +143,7 @@ public sealed class ATWebSocketProtocol : IDisposable
     /// <param name="cursor">The last known event seq number to backfill from.</param>
     /// <param name="token">Cancellation Token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task StartSubscribeLabelsAsync(int? cursor = default, CancellationToken? token = default)
+    public Task StartSubscribeLabelsAsync(long? cursor = default, CancellationToken? token = default)
     {
         this.subscribedLabels = true;
         var endPoint = "/xrpc/com.atproto.sync.subscribeLabels";

--- a/src/FishyFlip/Events/SubscribedLabelEventArgs.cs
+++ b/src/FishyFlip/Events/SubscribedLabelEventArgs.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="SubscribedLabelEventArgs.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Events;
+
+/// <summary>
+/// Subscribed Label Event Args.
+/// Fires when a labeler sends an update.
+/// </summary>
+public class SubscribedLabelEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubscribedLabelEventArgs"/> class.
+    /// </summary>
+    /// <param name="message"><see cref="SubscribeLabelMessage"/>.</param>
+    public SubscribedLabelEventArgs(SubscribeLabelMessage message)
+    {
+        this.Message = message;
+    }
+
+    /// <summary>
+    /// Gets the repo message.
+    /// </summary>
+    public SubscribeLabelMessage Message { get; }
+}

--- a/src/FishyFlip/Models/SubscribeLabelMessage.cs
+++ b/src/FishyFlip/Models/SubscribeLabelMessage.cs
@@ -15,21 +15,6 @@ public class SubscribeLabelMessage
     public FrameHeader? Header { get; internal set; }
 
     /// <summary>
-    /// Gets the commit of the message.
-    /// </summary>
-    public FrameCommit? Commit { get; internal set; }
-
-    /// <summary>
-    /// Gets the handle of the message.
-    /// </summary>
-    public FrameHandle? Handle { get; internal set; }
-
-    /// <summary>
-    /// Gets the footer of the message.
-    /// </summary>
-    public FrameFooter? Footer { get; internal set; }
-
-    /// <summary>
     /// Gets the atError of the message.
     /// </summary>
     public FrameError? Error { get; internal set; }
@@ -38,11 +23,6 @@ public class SubscribeLabelMessage
     /// Gets the info of the message.
     /// </summary>
     public FrameInfo? Info { get; internal set; }
-
-    /// <summary>
-    /// Gets the list of nodes in the message.
-    /// </summary>
-    public List<FrameNode> Nodes { get; } = new List<FrameNode>();
 
     /// <summary>
     /// Gets the labels of the message.

--- a/src/FishyFlip/Models/SubscribeLabelMessage.cs
+++ b/src/FishyFlip/Models/SubscribeLabelMessage.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="SubscribeLabelMessage.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Represents a message for subscribing to a labeler.
+/// </summary>
+public class SubscribeLabelMessage
+{
+    /// <summary>
+    /// Gets the header of the message.
+    /// </summary>
+    public FrameHeader? Header { get; internal set; }
+
+    /// <summary>
+    /// Gets the commit of the message.
+    /// </summary>
+    public FrameCommit? Commit { get; internal set; }
+
+    /// <summary>
+    /// Gets the handle of the message.
+    /// </summary>
+    public FrameHandle? Handle { get; internal set; }
+
+    /// <summary>
+    /// Gets the footer of the message.
+    /// </summary>
+    public FrameFooter? Footer { get; internal set; }
+
+    /// <summary>
+    /// Gets the atError of the message.
+    /// </summary>
+    public FrameError? Error { get; internal set; }
+
+    /// <summary>
+    /// Gets the info of the message.
+    /// </summary>
+    public FrameInfo? Info { get; internal set; }
+
+    /// <summary>
+    /// Gets the list of nodes in the message.
+    /// </summary>
+    public List<FrameNode> Nodes { get; } = new List<FrameNode>();
+
+    /// <summary>
+    /// Gets the labels of the message.
+    /// </summary>
+    public FishyFlip.Lexicon.Com.Atproto.Label.Labels? Labels { get; internal set; }
+}


### PR DESCRIPTION
Overtakes PR 192, this should implement subscribeLabels for the Firehose with its own object and event handle.

https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/label/subscribeLabels.json

<img width="868" alt="スクリーンショット 2025-02-08 12 34 23" src="https://github.com/user-attachments/assets/69a65ac3-5e32-4296-b416-3eb13e8933dc" />

This needs to be cleaned up a bit more, since you can't realistically connect labels and repos from the same service, as far as I'm aware, unless both happen to have them implemented. So it would probably make more sense to split these into two instances with the same core, rather than one web socket class. But this should at least get it working for now and not hack on the existing types.

This PR also adds `cursor` support, so if you track the `seq` value you can see it as a parameter when connecting for repo or labels, so you can backfill. You could have hacked that in by using `ConnectAsync` and setting your own URL, but this adds actually support for it.
