### PR TITLE
Map FrameNode/MST Entities

### DIFF
--- a/samples/Firehose/Program.cs
+++ b/samples/Firehose/Program.cs
@@ -68,7 +68,7 @@ atWebProtocol.OnRecordReceived += (sender, e) =>
     log.LogInformation($"Record: {e.Record?.Type}");
 };
 
-await atLabelWebProtocol.StartSubscribeLabelsAsync(0);
+await atWebProtocol.StartSubscribeReposAsync();
 
 var key = Console.Read();
 

--- a/src/FishyFlip/Models/FrameEntry.cs
+++ b/src/FishyFlip/Models/FrameEntry.cs
@@ -1,0 +1,45 @@
+// <copyright file="FrameEntry.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+using FishyFlip.Lexicon;
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Represents a frame entry.
+/// </summary>
+public class FrameEntry
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrameEntry"/> class.
+    /// </
+    /// <param name="obj">The CBOR object.</param>
+    public FrameEntry(CBORObject obj)
+    {
+        this.PrefixLength = obj["p"].AsInt64Value();
+        this.KeySuffix = obj["k"].EncodeToBytes();
+        this.Value = obj["v"].ToATCid()!;
+        this.Tree = obj["t"]?.ToATCid();
+    }
+
+    /// <summary>
+    /// Gets the count of bytes shared with previous TreeEntry in this Node (if any).
+    /// </summary>
+    public long PrefixLength { get; }
+
+    /// <summary>
+    /// Gets the remainder of key for this TreeEntry, after "prefixlen" have been removed.
+    /// </summary>
+    public byte[] KeySuffix { get; }
+
+    /// <summary>
+    /// Gets the link to the record data (CBOR) for this entry.
+    /// </summary>
+    public ATCid Value { get; }
+
+    /// <summary>
+    /// Gets the link to a sub-tree Node at a lower level which has keys sorting after this TreeEntry's key (to the "right"), but before the next TreeEntry's key in this Node (if any).
+    /// </summary>
+    public ATCid? Tree { get; }
+}

--- a/src/FishyFlip/Models/FrameFooter.cs
+++ b/src/FishyFlip/Models/FrameFooter.cs
@@ -20,7 +20,7 @@ public class FrameFooter
         this.Version = obj["version"].AsInt32();
         this.Prev = obj["prev"].ToATCid(logger);
         this.Data = obj["data"].ToATCid(logger);
-        this.Sig = obj["sig"].GetByteString();
+        this.Sig = obj["sig"].EncodeToBytes();
     }
 
     /// <summary>

--- a/src/FishyFlip/Models/FrameNode.cs
+++ b/src/FishyFlip/Models/FrameNode.cs
@@ -6,6 +6,7 @@ namespace FishyFlip.Models;
 
 /// <summary>
 /// Represents a node in a frame, containing data.
+/// https://atproto.com/ja/specs/repository.
 /// </summary>
 public class FrameNode
 {
@@ -15,11 +16,17 @@ public class FrameNode
     /// <param name="obj">The CBOR object to initialize the node with.</param>
     public FrameNode(CBORObject obj)
     {
-        this.Data = obj?.EncodeToBytes();
+        this.Left = obj["l"]?.ToATCid();
+        this.Entries = obj["e"]?.Values.Select(n => new FrameEntry(n)).ToArray();
     }
 
     /// <summary>
-    /// Gets the data contained in the node.
+    /// Gets the link to sub-tree Node on a lower level and with all keys sorting before keys at this node.
     /// </summary>
-    public byte[]? Data { get; }
+    public ATCid? Left { get; }
+
+    /// <summary>
+    /// Gets an ordered list of TreeEntry objects.
+    /// </summary>
+    public FrameEntry[]? Entries { get; }
 }


### PR DESCRIPTION
This adds the missing MST data that was stored in FrameNode, but unmapped.

https://atproto.com/ja/specs/repository

It should map to these types, and you should now be able to pull the information required to use the MST for data reconstruction/commits.