### PR TITLE
Add ATJetStreamBuilder options

### DIFF
--- a/src/FishyFlip/ATJetStreamBuilder.cs
+++ b/src/FishyFlip/ATJetStreamBuilder.cs
@@ -67,6 +67,71 @@ public class ATJetStreamBuilder
     }
 
     /// <summary>
+    /// Sets the wanted collections, up to 100.
+    /// </summary>
+    /// <param name="collections">NSID Collection types.</param>
+    /// <returns><see cref="ATJetStreamBuilder"/>.</returns>
+    public ATJetStreamBuilder WithWantedCollections(params string[] collections)
+    {
+        if (collections.Length > 100)
+        {
+            throw new ArgumentOutOfRangeException("Collections cannot exceed 100.");
+        }
+
+        this.atProtocolOptions.WantedCollections = collections;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the wanted DIDs, up to 10,000.
+    /// </summary>
+    /// <param name="dids">ATDids.</param>
+    /// <returns><see cref="ATJetStreamBuilder"/>.</returns>
+    public ATJetStreamBuilder WithWantedDids(params ATDid[] dids)
+    {
+        if (dids.Length > 10000)
+        {
+            throw new ArgumentOutOfRangeException("DIDs cannot exceed 10,000.");
+        }
+
+        this.atProtocolOptions.WantedDids = dids;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the max message size in bytes.
+    /// </summary>
+    /// <param name="maxMessageSizeBytes">Max message size in bytes.</param>
+    /// <returns><see cref="ATJetStreamBuilder"/>.</returns>
+    public ATJetStreamBuilder SetMaxMessageSizeBytes(int maxMessageSizeBytes)
+    {
+        this.atProtocolOptions.MaxMessageSizeBytes = maxMessageSizeBytes;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the require hello value.
+    /// </summary>
+    /// <param name="requireHello">Require Hello.</param>
+    /// <returns><see cref="ATJetStreamBuilder"/>.</returns>
+    public ATJetStreamBuilder SetRequireHello(bool requireHello)
+    {
+        this.atProtocolOptions.RequireHello = requireHello;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the cursor.
+    /// </summary>
+    /// <param name="cursor">Cursor.</param>
+    /// <returns><see cref="ATJetStreamBuilder"/>.</returns>
+    public ATJetStreamBuilder WithCursor(long cursor)
+    {
+        this.atProtocolOptions.Cursor = cursor;
+        return this;
+    }
+
+    /// <summary>
     /// Returns the ATWebSocketProtocolOptions.
     /// </summary>
     /// <returns>ATJetStreamBuilder.</returns>

--- a/src/FishyFlip/ATJetStreamOptions.cs
+++ b/src/FishyFlip/ATJetStreamOptions.cs
@@ -51,6 +51,31 @@ public class ATJetStreamOptions
     public byte[]? Dictionary { get; internal set; }
 
     /// <summary>
+    /// Gets the wanted collections.
+    /// </summary>
+    public string[] WantedCollections { get; internal set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets the wanted DIDs.
+    /// </summary>
+    public ATDid[] WantedDids { get; internal set; } = Array.Empty<ATDid>();
+
+    /// <summary>
+    /// Gets the max message size in bytes.
+    /// </summary>
+    public int MaxMessageSizeBytes { get; internal set; } = 0;
+
+    /// <summary>
+    /// Gets the cursor.
+    /// </summary>
+    public long? Cursor { get; internal set; }
+
+    /// <summary>
+    /// Gets a value indicating whether to require a pause replay/live-tail until the server recevies a SubscriberOptionsUpdatePayload over the socket in a Subscriber Sourced Message.
+    /// </summary>
+    public bool RequireHello { get; internal set; } = false;
+
+    /// <summary>
     /// Gets the JsonSerializerOptions.
     /// </summary>
     public JsonSerializerOptions JsonSerializerOptions { get; internal set; }

--- a/src/FishyFlip/Models/ATDid.cs
+++ b/src/FishyFlip/Models/ATDid.cs
@@ -2,6 +2,9 @@
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 
+#nullable enable annotations
+#nullable disable warnings
+
 namespace FishyFlip.Models;
 
 /// <summary>
@@ -57,7 +60,7 @@ public class ATDid : ATIdentifier
     /// <param name="uri">String based URI.</param>
     /// <param name="atDid">A new instance of the <see cref="ATDid"/> class.</param>
     /// <returns>Bool if ATDid is valid.</returns>
-    public static bool TryCreate(string uri, out ATDid? atDid)
+    public static bool TryCreate(string uri, out ATDid atDid)
     {
         try
         {

--- a/src/FishyFlip/Models/ATHandle.cs
+++ b/src/FishyFlip/Models/ATHandle.cs
@@ -2,6 +2,9 @@
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 
+#nullable enable annotations
+#nullable disable warnings
+
 namespace FishyFlip.Models;
 
 /// <summary>
@@ -52,7 +55,7 @@ public class ATHandle : ATIdentifier
     /// <param name="uri">String based URI.</param>
     /// <param name="atHandle">A new instance of the <see cref="ATHandle"/> class.</param>
     /// <returns>Bool if ATHandle is valid.</returns>
-    public static bool TryCreate(string uri, out ATHandle? atHandle)
+    public static bool TryCreate(string uri, out ATHandle atHandle)
     {
         try
         {

--- a/src/FishyFlip/Models/ATIdentifier.cs
+++ b/src/FishyFlip/Models/ATIdentifier.cs
@@ -2,6 +2,9 @@
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 
+#nullable enable annotations
+#nullable disable warnings
+
 namespace FishyFlip.Models;
 
 /// <summary>
@@ -35,7 +38,7 @@ public abstract class ATIdentifier
     /// <param name="uri">String based URI.</param>
     /// <param name="atIdentifier">A new instance of the <see cref="ATIdentifier"/> class.</param>
     /// <returns>Bool if ATIdentifier is valid.</returns>
-    public static bool TryCreate(string uri, out ATIdentifier? atIdentifier)
+    public static bool TryCreate(string uri, out ATIdentifier atIdentifier)
     {
         try
         {

--- a/src/FishyFlip/Models/ATUri.cs
+++ b/src/FishyFlip/Models/ATUri.cs
@@ -2,6 +2,9 @@
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 
+#nullable enable annotations
+#nullable disable warnings
+
 namespace FishyFlip.Models;
 
 /// <summary>
@@ -115,7 +118,7 @@ public class ATUri
     /// <param name="uri">String based URI.</param>
     /// <param name="atUri">A new instance of the <see cref="ATUri"/> class.</param>
     /// <returns>Bool if ATUri is valid.</returns>
-    public static bool TryCreate(string uri, out ATUri? atUri)
+    public static bool TryCreate(string uri, out ATUri atUri)
     {
         try
         {


### PR DESCRIPTION
This replaces some code in ATJetStreamBuilder to move the options over to it, rather than through the ConnectAsync parameters. This matches with what the Firehose has.

I also changed the `TryCreate` methods to remove the null check for the out parameter, since the point should be to use the bool for that, this reduces the need to null check again for the out parameter.