### PR TITLE
Implement Car/RepoResponse

### DIFF
--- a/src/FishyFlip/ATWebSocketProtocol.cs
+++ b/src/FishyFlip/ATWebSocketProtocol.cs
@@ -301,7 +301,7 @@ public sealed class ATWebSocketProtocol : IDisposable
                             break;
                         }
 
-                        void HandleProgressStatus(CarProgressStatusEvent e)
+                        foreach (var e in CarDecoder.DecodeCar(frameCommit.Blocks))
                         {
                             using var blockStream = new MemoryStream(e.Bytes);
                             var blockObj = CBORObject.Read(blockStream);
@@ -321,8 +321,6 @@ public sealed class ATWebSocketProtocol : IDisposable
                                 message.Nodes.Add(new FrameNode(blockObj));
                             }
                         }
-
-                        CarDecoder.DecodeCar(frameCommit.Blocks, HandleProgressStatus);
 
                         break;
                     case "#handle":

--- a/src/FishyFlip/IRepoEntry.cs
+++ b/src/FishyFlip/IRepoEntry.cs
@@ -1,0 +1,13 @@
+// <copyright file="IRepoEntry.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip;
+
+/// <summary>
+/// IRepoEntry represents items that can be served within a Repo entry file,
+/// such as the ones served through <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.SyncEndpoints.GetRepoAsync(FishyFlip.ATProtocol, ATDid, OnCarDecoded, string?, CancellationToken)"/>.
+/// </summary>
+public interface IRepoEntry
+{
+}

--- a/src/FishyFlip/Lexicon/ATObject.g.cs
+++ b/src/FishyFlip/Lexicon/ATObject.g.cs
@@ -10,7 +10,7 @@ namespace FishyFlip.Lexicon
     /// <summary>
     /// The base class for FishyFlip ATProtocol Objects.
     /// </summary>
-    public partial class ATObject : ICBOREncodable<ATObject>, IJsonEncodable<ATObject>
+    public partial class ATObject : ICBOREncodable<ATObject>, IJsonEncodable<ATObject>, IRepoEntry
     {
 
         public ATObject() { }
@@ -53,6 +53,11 @@ namespace FishyFlip.Lexicon
         public virtual byte[]? ToUtf8Json()
         {
              return null;
+        }
+
+        public override string ToString()
+        {
+            return this.ToJson();
         }
 
         internal static ATObject? ToATObject(string text, string type)

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/ATProtoSync.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/ATProtoSync.g.cs
@@ -62,7 +62,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <param name="cids"></param>
         /// <param name="onDecoded"></param>
         /// <param name="cancellationToken"></param>
-        public Task<Result<Success?>> GetBlocksAsync (FishyFlip.Models.ATDid did, List<string> cids, OnCarDecoded onDecoded, CancellationToken cancellationToken = default)
+        public Task<Result<CarResponse?>> GetBlocksAsync (FishyFlip.Models.ATDid did, List<string> cids, OnCarDecoded? onDecoded = default, CancellationToken cancellationToken = default)
         {
             return atp.GetBlocksAsync(did, cids, onDecoded, cancellationToken);
         }
@@ -98,7 +98,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <param name="rkey">Record Key</param>
         /// <param name="onDecoded"></param>
         /// <param name="cancellationToken"></param>
-        public Task<Result<Success?>> GetRecordAsync (FishyFlip.Models.ATDid did, string collection, string rkey, OnCarDecoded onDecoded, CancellationToken cancellationToken = default)
+        public Task<Result<CarResponse?>> GetRecordAsync (FishyFlip.Models.ATDid did, string collection, string rkey, OnCarDecoded? onDecoded = default, CancellationToken cancellationToken = default)
         {
             return atp.GetRecordAsync(did, collection, rkey, onDecoded, cancellationToken);
         }
@@ -113,12 +113,12 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <see cref="FishyFlip.Lexicon.RepoDeactivatedError"/>  <br/>
         /// </summary>
         /// <param name="did">The DID of the repo.</param>
-        /// <param name="onDecoded"></param>
         /// <param name="since">The revision ('rev') of the repo to create a diff from.</param>
+        /// <param name="onDecoded"></param>
         /// <param name="cancellationToken"></param>
-        public Task<Result<Success?>> GetRepoAsync (FishyFlip.Models.ATDid did, OnCarDecoded onDecoded, string? since = default, CancellationToken cancellationToken = default)
+        public Task<Result<CarResponse?>> GetRepoAsync (FishyFlip.Models.ATDid did, string? since = default, OnCarDecoded? onDecoded = default, CancellationToken cancellationToken = default)
         {
-            return atp.GetRepoAsync(did, onDecoded, since, cancellationToken);
+            return atp.GetRepoAsync(did, since, onDecoded, cancellationToken);
         }
 
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
@@ -81,8 +81,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <param name="cids"></param>
         /// <param name="onDecoded"></param>
         /// <param name="cancellationToken"></param>
-        /// <returns>Result of <see cref="Success?"/></returns>
-        public static Task<Result<Success?>> GetBlocksAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, List<string> cids, OnCarDecoded onDecoded, CancellationToken cancellationToken = default)
+        /// <returns>Result of <see cref="CarResponse?"/></returns>
+        public static Task<Result<CarResponse?>> GetBlocksAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, List<string> cids, OnCarDecoded? onDecoded = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetBlocks.ToString();
             endpointUrl += "?";
@@ -91,7 +91,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
 
             queryStrings.Add(string.Join("&", cids.Select(n => "cids=" + n)));
 
-            queryStrings.Add("onDecoded=" + onDecoded);
+            if (onDecoded != null)
+            {
+                queryStrings.Add("onDecoded=" + onDecoded);
+            }
 
             var headers = new Dictionary<string, string>();
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
@@ -141,8 +144,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <param name="rkey">Record Key</param>
         /// <param name="onDecoded"></param>
         /// <param name="cancellationToken"></param>
-        /// <returns>Result of <see cref="Success?"/></returns>
-        public static Task<Result<Success?>> GetRecordAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, string collection, string rkey, OnCarDecoded onDecoded, CancellationToken cancellationToken = default)
+        /// <returns>Result of <see cref="CarResponse?"/></returns>
+        public static Task<Result<CarResponse?>> GetRecordAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, string collection, string rkey, OnCarDecoded? onDecoded = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetRecord.ToString();
             endpointUrl += "?";
@@ -153,7 +156,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
 
             queryStrings.Add("rkey=" + rkey);
 
-            queryStrings.Add("onDecoded=" + onDecoded);
+            if (onDecoded != null)
+            {
+                queryStrings.Add("onDecoded=" + onDecoded);
+            }
 
             var headers = new Dictionary<string, string>();
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
@@ -172,22 +178,25 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// </summary>
         /// <param name="atp"></param>
         /// <param name="did">The DID of the repo.</param>
-        /// <param name="onDecoded"></param>
         /// <param name="since">The revision ('rev') of the repo to create a diff from.</param>
+        /// <param name="onDecoded"></param>
         /// <param name="cancellationToken"></param>
-        /// <returns>Result of <see cref="Success?"/></returns>
-        public static Task<Result<Success?>> GetRepoAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, OnCarDecoded onDecoded, string? since = default, CancellationToken cancellationToken = default)
+        /// <returns>Result of <see cref="CarResponse?"/></returns>
+        public static Task<Result<CarResponse?>> GetRepoAsync (this FishyFlip.ATProtocol atp, FishyFlip.Models.ATDid did, string? since = default, OnCarDecoded? onDecoded = default, CancellationToken cancellationToken = default)
         {
             var endpointUrl = GetRepo.ToString();
             endpointUrl += "?";
             List<string> queryStrings = new();
             queryStrings.Add("did=" + did);
 
-            queryStrings.Add("onDecoded=" + onDecoded);
-
             if (since != null)
             {
                 queryStrings.Add("since=" + since);
+            }
+
+            if (onDecoded != null)
+            {
+                queryStrings.Add("onDecoded=" + onDecoded);
             }
 
             var headers = new Dictionary<string, string>();

--- a/src/FishyFlip/Models/CarResponse.cs
+++ b/src/FishyFlip/Models/CarResponse.cs
@@ -1,0 +1,71 @@
+// <copyright file="CarResponse.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Represents a response from a CAR file.
+/// This can only be used once.
+/// </summary>
+public class CarResponse : IAsyncEnumerable<FrameEvent>, IDisposable
+{
+    private readonly HttpResponseMessage response;
+
+    private bool disposedValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CarResponse"/> class.
+    /// </summary>
+    /// <param name="response">HttpResponseMessage.</param>
+    internal CarResponse(HttpResponseMessage response)
+    {
+        this.response = response;
+    }
+
+    /// <summary>
+    /// Fetch Repo Items from a given CarResponse.
+    /// </summary>
+    /// <returns><see cref="RepoResponse"/>.</returns>
+    public RepoResponse FetchRepo()
+    {
+        if (this.disposedValue)
+        {
+            throw new ObjectDisposedException(nameof(CarResponse));
+        }
+
+        return RepoResponse.FromCarResponse(this);
+    }
+
+    /// <summary>
+    /// Disposes the response.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        this.disposedValue = true;
+        this.response.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerator<FrameEvent> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        if (this.disposedValue)
+        {
+            throw new ObjectDisposedException(nameof(CarResponse));
+        }
+
+#if NETSTANDARD
+        var stream = await this.response.Content.ReadAsStreamAsync();
+#else
+        var stream = await this.response.Content.ReadAsStreamAsync(cancellationToken);
+#endif
+
+        await foreach (var item in CarDecoder.DecodeCarAsync(stream))
+        {
+            yield return item;
+        }
+
+        this.response.Dispose();
+    }
+}

--- a/src/FishyFlip/Models/FrameEntry.cs
+++ b/src/FishyFlip/Models/FrameEntry.cs
@@ -9,7 +9,7 @@ namespace FishyFlip.Models;
 /// <summary>
 /// Represents a frame entry.
 /// </summary>
-public class FrameEntry
+public class FrameEntry : IRepoEntry
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FrameEntry"/> class.

--- a/src/FishyFlip/Models/FrameEvent.cs
+++ b/src/FishyFlip/Models/FrameEvent.cs
@@ -1,0 +1,41 @@
+// <copyright file="FrameEvent.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Represents an event that contains the progress status of a car.
+/// </summary>
+public class FrameEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrameEvent"/> class.
+    /// </summary>
+    /// <param name="cid">The car ID.</param>
+    /// <param name="bytes">The progress status bytes.</param>
+    public FrameEvent(ATCid cid, byte[] bytes)
+    {
+        this.Cid = cid;
+        this.Bytes = bytes;
+    }
+
+    /// <summary>
+    /// Gets the progress status bytes.
+    /// </summary>
+    public byte[] Bytes { get; }
+
+    /// <summary>
+    /// Gets the car ID.
+    /// </summary>
+    public ATCid Cid { get; }
+
+    /// <summary>
+    /// Returns a string that represents the current object.
+    /// </summary>
+    /// <returns>A string that represents the current object.</returns>
+    public override string ToString()
+    {
+        return $"{this.Cid} - {this.Bytes.Length}";
+    }
+}

--- a/src/FishyFlip/Models/FrameFooter.cs
+++ b/src/FishyFlip/Models/FrameFooter.cs
@@ -7,7 +7,7 @@ namespace FishyFlip.Models;
 /// <summary>
 /// Represents the footer of a frame in the FishyFlip application.
 /// </summary>
-public class FrameFooter
+public class FrameFooter : IRepoEntry
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FrameFooter"/> class.

--- a/src/FishyFlip/Models/FrameNode.cs
+++ b/src/FishyFlip/Models/FrameNode.cs
@@ -8,7 +8,7 @@ namespace FishyFlip.Models;
 /// Represents a node in a frame, containing data.
 /// https://atproto.com/ja/specs/repository.
 /// </summary>
-public class FrameNode
+public class FrameNode : IRepoEntry
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FrameNode"/> class with the specified CBOR object.

--- a/src/FishyFlip/Models/RepoResponse.cs
+++ b/src/FishyFlip/Models/RepoResponse.cs
@@ -1,0 +1,67 @@
+// <copyright file="RepoResponse.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+using FishyFlip.Lexicon.Com.Atproto.Sync;
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Wraps a <see cref="CarResponse"/> and returns <see cref="ATObject"/>s.
+/// This can only be used once.
+/// </summary>
+public class RepoResponse : IAsyncEnumerable<ATObject>, IDisposable
+{
+    private readonly CarResponse carResponse;
+    private bool disposedValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RepoResponse"/> class.
+    /// </summary>
+    /// <param name="carResponse">CarResponse.</param>
+    internal RepoResponse(CarResponse carResponse)
+    {
+        this.carResponse = carResponse;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="RepoResponse"/> from a <see cref="CarResponse"/>.
+    /// </summary>
+    /// <param name="carResponse"><see cref="CarResponse"/>.</param>
+    /// <returns><see cref="RepoResponse"/>.</returns>
+    public static RepoResponse FromCarResponse(CarResponse carResponse)
+    {
+        return new RepoResponse(carResponse);
+    }
+
+    /// <summary>
+    /// Disposes the response.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        this.disposedValue = true;
+        this.carResponse.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerator<ATObject> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        if (this.disposedValue)
+        {
+            throw new ObjectDisposedException(nameof(RepoResponse));
+        }
+
+        await foreach (var item in this.carResponse)
+        {
+            using var blockStream = new MemoryStream(item.Bytes);
+            var blockObj = CBORObject.Read(blockStream);
+            if (blockObj.IsATObject())
+            {
+                yield return blockObj.ToATObject();
+            }
+        }
+
+        this.carResponse.Dispose();
+    }
+}

--- a/src/FishyFlip/Models/Result.cs
+++ b/src/FishyFlip/Models/Result.cs
@@ -15,7 +15,7 @@ public class Result<T> : Multiple<T, ATError>
     /// </summary>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <param name="value">Represents the type of value.</param>
-    private Result(T value)
+    internal Result(T? value)
         : base(0, value, default)
     {
     }
@@ -24,7 +24,7 @@ public class Result<T> : Multiple<T, ATError>
     /// Initializes a new instance of the <see cref="Result{T}"/> class.
     /// </summary>
     /// <param name="value">Represents the type of value.</param>
-    private Result(ATError? value)
+    internal Result(ATError? value)
         : base(1, default, value)
     {
     }

--- a/src/FishyFlip/Tools/ATProtocolExtensions.cs
+++ b/src/FishyFlip/Tools/ATProtocolExtensions.cs
@@ -58,7 +58,7 @@ public static class ATProtocolExtensions
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <param name="progress">The progress reporter for the decoding process. This is optional and defaults to null.</param>
     /// <returns>The Task that represents the asynchronous operation. The value of the TResult parameter contains the Success response message as the result.</returns>
-    public static async Task<Result<Success?>> GetCarAsync(
+    public static async Task<Result<CarResponse>> GetCarAsync(
             this ATProtocol protocol,
             string url,
             CancellationToken cancellationToken,

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -1666,7 +1666,7 @@ public partial class AppCommands
 
         if (classGeneration.Definition.Output?.Encoding == "application/vnd.ipld.car")
         {
-            requiredProperties.Add("OnCarDecoded onDecoded");
+            optionalProperties.Add("OnCarDecoded? onDecoded = default");
         }
 
         if (isExtensionMethod)
@@ -1715,6 +1715,11 @@ public partial class AppCommands
         if (classGeneration.Definition.Output?.Encoding == "*/*")
         {
             return "byte[]";
+        }
+
+        if (classGeneration.Definition.Output?.Encoding == "application/vnd.ipld.car")
+        {
+            return "CarResponse";
         }
 
         if (classGeneration.Definition.Output?.Schema is null)
@@ -2508,7 +2513,7 @@ public partial class AppCommands
         sb.AppendLine($"    /// <summary>");
         sb.AppendLine($"    /// The base class for FishyFlip ATProtocol Objects.");
         sb.AppendLine($"    /// </summary>");
-        sb.AppendLine($"    public partial class ATObject : ICBOREncodable<ATObject>, IJsonEncodable<ATObject>");
+        sb.AppendLine($"    public partial class ATObject : ICBOREncodable<ATObject>, IJsonEncodable<ATObject>, IRepoEntry");
         sb.AppendLine("    {");
         sb.AppendLine();
         sb.AppendLine("        public ATObject() { }");
@@ -2564,6 +2569,11 @@ public partial class AppCommands
         // sb.AppendLine("                default:");
         // sb.AppendLine("                    return JsonSerializer.SerializeToUtf8Bytes((ATObject)this, SourceGenerationContext.Default.ATObject);");
         // sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine($"        public override string ToString()");
+        sb.AppendLine("        {");
+        sb.AppendLine("            return this.ToJson();");
         sb.AppendLine("        }");
         sb.AppendLine();
         sb.AppendLine("        internal static ATObject? ToATObject(string text, string type)");


### PR DESCRIPTION
This PR refactors the CAR response endpoints to return a new type, `CarResponse`. This IAsyncEnumerable can be pulled to pull `FrameEvent` items from it to turn them into MST or ATObject types. I also created a new `RepoResponse` class that only outputs ATObject types.

This will pull from the HTTP Response as you get items from it, and it does not download the entire object simultaneously. It also removes the need to add the OnCarDecoded delegate method, which is now obsolete.

This PR also adds a ToString override for ATObject to output the JSON from the type, making debugging a given ATObject easier.