### PR TITLE
Fix ignored result of RefreshSessionAsync()

### DIFF
--- a/src/FishyFlip/ATProtocol.cs
+++ b/src/FishyFlip/ATProtocol.cs
@@ -309,7 +309,7 @@ public sealed partial class ATProtocol : IDisposable
                 var result = await oAuth2SessionManager.RefreshTokenAsync();
                 return oAuth2SessionManager.OAuthSession;
             case PasswordSessionManager { Session: not null } passwordManager:
-                await passwordManager.RefreshSessionAsync();
+                (await passwordManager.RefreshSessionAsync()).HandleResult();
                 return new AuthSession(passwordManager.Session);
             default:
                 return null;


### PR DESCRIPTION
I was wondering why a PDS API was failing even after "successfully" refreshing the session token.
The problem was that the refresh token was itself expired, but `RefreshAuthSessionAsync` silently swallowed that error.