### PR TITLE
Fix Comments and Doc Generation

### DIFF
--- a/src/FishyFlip/ATObjectCollectionAsyncEnumerator.cs
+++ b/src/FishyFlip/ATObjectCollectionAsyncEnumerator.cs
@@ -1,4 +1,4 @@
-// <copyright file="ATObjectCollectionAsyncEnumerator{T}.cs" company="Drastic Actions">
+// <copyright file="ATObjectCollectionAsyncEnumerator.cs" company="Drastic Actions">
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 

--- a/src/FishyFlip/ATObjectCollectionBase.cs
+++ b/src/FishyFlip/ATObjectCollectionBase.cs
@@ -1,4 +1,4 @@
-// <copyright file="ATObjectCollectionBase{T}.cs" company="Drastic Actions">
+// <copyright file="ATObjectCollectionBase.cs" company="Drastic Actions">
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 

--- a/src/FishyFlip/IATObjectCollection.cs
+++ b/src/FishyFlip/IATObjectCollection.cs
@@ -1,4 +1,4 @@
-// <copyright file="IATObjectCollection{T}.cs" company="Drastic Actions">
+// <copyright file="IATObjectCollection.cs" company="Drastic Actions">
 // Copyright (c) Drastic Actions. All rights reserved.
 // </copyright>
 

--- a/src/FishyFlip/IRepoEntry.cs
+++ b/src/FishyFlip/IRepoEntry.cs
@@ -6,7 +6,7 @@ namespace FishyFlip;
 
 /// <summary>
 /// IRepoEntry represents items that can be served within a Repo entry file,
-/// such as the ones served through <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.SyncEndpoints.GetRepoAsync(FishyFlip.ATProtocol, ATDid, OnCarDecoded, string?, CancellationToken)"/>.
+/// such as the ones served through GetRepoAsync."/>.
 /// </summary>
 public interface IRepoEntry
 {

--- a/src/FishyFlip/Models/FacetActorIdentifier.cs
+++ b/src/FishyFlip/Models/FacetActorIdentifier.cs
@@ -8,6 +8,6 @@ namespace FishyFlip.Models;
 /// Facet Actor Identifier, used to identify an actor in a facet to create a mention.
 /// The Handle and Did are not validated to be for the same actor.
 /// </summary>
-/// <param name="Handle"><see cref="ATHandle."/>.</param>
+/// <param name="Handle"><see cref="ATHandle"/>.</param>
 /// <param name="Did"><see cref="ATDid"/>.</param>
 public record FacetActorIdentifier(ATHandle Handle, ATDid Did);

--- a/src/FishyFlip/Models/FrameEntry.cs
+++ b/src/FishyFlip/Models/FrameEntry.cs
@@ -13,7 +13,7 @@ public class FrameEntry : IRepoEntry
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FrameEntry"/> class.
-    /// </
+    /// </summary>
     /// <param name="obj">The CBOR object.</param>
     public FrameEntry(CBORObject obj)
     {

--- a/src/FishyFlip/Models/FrameIdentity.cs
+++ b/src/FishyFlip/Models/FrameIdentity.cs
@@ -11,7 +11,7 @@ public class FrameIdentity
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FrameIdentity"/> class.
-    /// </
+    /// </summary>
     /// <param name="obj">The CBOR object containing the identity information.</param>
     public FrameIdentity(CBORObject obj)
     {

--- a/src/FishyFlip/Tools/BatchItemExtensions.cs
+++ b/src/FishyFlip/Tools/BatchItemExtensions.cs
@@ -14,7 +14,7 @@ public static class BatchItemExtensions
     /// <summary>
     /// Collects all elements of the specified asynchronous sequence into a read-only list.
     /// </summary>
-    /// <typeparam name="T">The type of elements in the source sequence, which must implement <see cref="IBatchItem"/>.</typeparam>
+    /// <typeparam name="T">The type of elements in the source sequence.</typeparam>
     /// <param name="source">The asynchronous sequence to collect elements from.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a read-only list of the collected elements.</returns>
     public static async ValueTask<IReadOnlyList<T>> CollectAsync<T>(this IAsyncEnumerable<T> source)
@@ -23,7 +23,7 @@ public static class BatchItemExtensions
     /// <summary>
     /// Collects a specified number of items from an asynchronous enumerable sequence and returns them as a read-only list.
     /// </summary>
-    /// <typeparam name="T">The type of elements in the source sequence, which must implement <see cref="IBatchItem"/>.</typeparam>
+    /// <typeparam name="T">The type of elements in the source sequence.</typeparam>
     /// <param name="source">The asynchronous enumerable sequence to collect items from.</param>
     /// <param name="count">The number of items to collect from the source sequence.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a read-only list of collected items.</returns>


### PR DESCRIPTION
docfx doesn't like `{T}` in filenames, so I'm dropping them, this also fixes some typos I made in some comments that are not source generated.