### PR TITLE
Allow for multiple records in SubscribeRepoMessage

### DIFF
--- a/src/FishyFlip/Models/SubscribeRepoMessage.cs
+++ b/src/FishyFlip/Models/SubscribeRepoMessage.cs
@@ -32,7 +32,13 @@ public class SubscribeRepoMessage
     /// <summary>
     /// Gets the record of the message.
     /// </summary>
-    public ATObject? Record { get; internal set; }
+    [Obsolete("Use Records instead.")]
+    public ATObject? Record => this.Records?.FirstOrDefault();
+
+    /// <summary>
+    /// Gets the records of the message.
+    /// </summary>
+    public IReadOnlyList<ATObject>? Records { get; internal set; }
 
     /// <summary>
     /// Gets the atError of the message.


### PR DESCRIPTION
`SubscribeRepoMessage` has a convenience property for retrieving records from a given commit, but I assumed that there would only be one record within a block. That's not true; you could have multiple references to the ops contained within the commit. 

This PR fixes it by making it `Records` and allowing for multiple records to be returned. `Record` is kept for backwards compatibility as an obsolete property that returns the first record in the list.

Fixes #262 