### PR TITLE
Add JsonIgnore WhenNull to unrequired values directly

### DIFF
--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/BskyAppStatePref.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/BskyAppStatePref.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.BskyAppProgressGuide"/> (app.bsky.actor.defs#bskyAppProgressGuide)
         /// </summary>
         [JsonPropertyName("activeProgressGuide")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.BskyAppProgressGuide? ActiveProgressGuide { get; set; }
 
         /// <summary>
@@ -62,6 +63,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user.
         /// </summary>
         [JsonPropertyName("queuedNudges")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? QueuedNudges { get; set; }
 
         /// <summary>
@@ -69,6 +71,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Storage for NUXs the user has encountered.
         /// </summary>
         [JsonPropertyName("nuxs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Actor.Nux>? Nuxs { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#bskyAppStatePref";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ContentLabelPref.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ContentLabelPref.g.cs
@@ -56,6 +56,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Which labeler does this preference apply to? If undefined, applies globally.
         /// </summary>
         [JsonPropertyName("labelerDid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? LabelerDid { get; set; }
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/FeedViewPref.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/FeedViewPref.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Hide replies in the feed.
         /// </summary>
         [JsonPropertyName("hideReplies")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? HideReplies { get; set; }
 
         /// <summary>
@@ -74,6 +75,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Hide replies in the feed if they are not by followed users.
         /// </summary>
         [JsonPropertyName("hideRepliesByUnfollowed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? HideRepliesByUnfollowed { get; set; } = true;
 
         /// <summary>
@@ -81,6 +83,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Hide replies in the feed if they do not have this number of likes.
         /// </summary>
         [JsonPropertyName("hideRepliesByLikeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? HideRepliesByLikeCount { get; set; }
 
         /// <summary>
@@ -88,6 +91,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Hide reposts in the feed.
         /// </summary>
         [JsonPropertyName("hideReposts")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? HideReposts { get; set; }
 
         /// <summary>
@@ -95,6 +99,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Hide quote posts in the feed.
         /// </summary>
         [JsonPropertyName("hideQuotePosts")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? HideQuotePosts { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#feedViewPref";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/GetSuggestionsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/GetSuggestionsOutput.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>
@@ -63,6 +64,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Snowflake for this recommendation, use when submitting recommendation events.
         /// </summary>
         [JsonPropertyName("recId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RecId { get; set; }
 
         public const string RecordType = "app.bsky.actor.getSuggestions#GetSuggestionsOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/MutedWord.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/MutedWord.g.cs
@@ -62,6 +62,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the id.
         /// </summary>
         [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Id { get; set; }
 
         /// <summary>
@@ -88,6 +89,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// exclude-following <br/>
         /// </summary>
         [JsonPropertyName("actorTarget")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ActorTarget { get; set; } = "all";
 
         /// <summary>
@@ -95,6 +97,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> The date and time at which the muted word will expire and no longer be applied.
         /// </summary>
         [JsonPropertyName("expiresAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? ExpiresAt { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#mutedWord";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/Nux.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/Nux.g.cs
@@ -70,6 +70,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters.
         /// </summary>
         [JsonPropertyName("data")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Data { get; set; }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> The date and time at which the NUX will expire and should be considered completed.
         /// </summary>
         [JsonPropertyName("expiresAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? ExpiresAt { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#nux";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/PersonalDetailsPref.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/PersonalDetailsPref.g.cs
@@ -44,6 +44,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> The birth date of account owner.
         /// </summary>
         [JsonPropertyName("birthDate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? BirthDate { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#personalDetailsPref";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/PostInteractionSettingsPref.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/PostInteractionSettingsPref.g.cs
@@ -64,6 +64,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ListRule"/> (app.bsky.feed.threadgate#listRule) <br/>
         /// </summary>
         [JsonPropertyName("threadgateAllowRules")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<ATObject>? ThreadgateAllowRules { get; set; }
 
         /// <summary>
@@ -73,6 +74,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.DisableRule"/> (app.bsky.feed.postgate#disableRule) <br/>
         /// </summary>
         [JsonPropertyName("postgateEmbeddingRules")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Feed.DisableRule>? PostgateEmbeddingRules { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#postInteractionSettingsPref";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/Profile.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/Profile.g.cs
@@ -74,6 +74,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
@@ -81,6 +82,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Free-form profile description text.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -88,6 +90,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Small image to be displayed next to posts from account. AKA, 'profile picture'
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Avatar { get; set; }
 
         /// <summary>
@@ -95,6 +98,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Larger horizontal image to display behind profile view.
         /// </summary>
         [JsonPropertyName("banner")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Banner { get; set; }
 
         /// <summary>
@@ -104,6 +108,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         /// <summary>
@@ -111,6 +116,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("joinedViaStarterPack")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? JoinedViaStarterPack { get; set; }
 
         /// <summary>
@@ -118,12 +124,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("pinnedPost")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? PinnedPost { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.actor.profile";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileAssociated.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileAssociated.g.cs
@@ -57,24 +57,28 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the lists.
         /// </summary>
         [JsonPropertyName("lists")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Lists { get; set; }
 
         /// <summary>
         /// Gets or sets the feedgens.
         /// </summary>
         [JsonPropertyName("feedgens")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Feedgens { get; set; }
 
         /// <summary>
         /// Gets or sets the starterPacks.
         /// </summary>
         [JsonPropertyName("starterPacks")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? StarterPacks { get; set; }
 
         /// <summary>
         /// Gets or sets the labeler.
         /// </summary>
         [JsonPropertyName("labeler")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Labeler { get; set; }
 
         /// <summary>
@@ -82,6 +86,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociatedChat"/> (app.bsky.actor.defs#profileAssociatedChat)
         /// </summary>
         [JsonPropertyName("chat")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociatedChat? Chat { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#profileAssociated";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileView.g.cs
@@ -100,18 +100,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
@@ -119,18 +122,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated"/> (app.bsky.actor.defs#profileAssociated)
         /// </summary>
         [JsonPropertyName("associated")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated? Associated { get; set; }
 
         /// <summary>
         /// Gets or sets the indexedAt.
         /// </summary>
         [JsonPropertyName("indexedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? IndexedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -138,12 +144,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ViewerState"/> (app.bsky.actor.defs#viewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ViewerState? Viewer { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -151,6 +159,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.VerificationState"/> (app.bsky.actor.defs#verificationState)
         /// </summary>
         [JsonPropertyName("verification")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.VerificationState? Verification { get; set; }
 
         /// <summary>
@@ -158,6 +167,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.StatusView"/> (app.bsky.actor.defs#statusView)
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.StatusView? Status { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#profileView";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileViewBasic.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileViewBasic.g.cs
@@ -94,12 +94,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
@@ -107,6 +109,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated"/> (app.bsky.actor.defs#profileAssociated)
         /// </summary>
         [JsonPropertyName("associated")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated? Associated { get; set; }
 
         /// <summary>
@@ -114,18 +117,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ViewerState"/> (app.bsky.actor.defs#viewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ViewerState? Viewer { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -133,6 +139,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.VerificationState"/> (app.bsky.actor.defs#verificationState)
         /// </summary>
         [JsonPropertyName("verification")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.VerificationState? Verification { get; set; }
 
         /// <summary>
@@ -140,6 +147,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.StatusView"/> (app.bsky.actor.defs#statusView)
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.StatusView? Status { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#profileViewBasic";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileViewDetailed.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ProfileViewDetailed.g.cs
@@ -122,42 +122,49 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the banner.
         /// </summary>
         [JsonPropertyName("banner")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Banner { get; set; }
 
         /// <summary>
         /// Gets or sets the followersCount.
         /// </summary>
         [JsonPropertyName("followersCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? FollowersCount { get; set; }
 
         /// <summary>
         /// Gets or sets the followsCount.
         /// </summary>
         [JsonPropertyName("followsCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? FollowsCount { get; set; }
 
         /// <summary>
         /// Gets or sets the postsCount.
         /// </summary>
         [JsonPropertyName("postsCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? PostsCount { get; set; }
 
         /// <summary>
@@ -165,6 +172,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated"/> (app.bsky.actor.defs#profileAssociated)
         /// </summary>
         [JsonPropertyName("associated")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated? Associated { get; set; }
 
         /// <summary>
@@ -172,18 +180,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Graph.StarterPackViewBasic"/> (app.bsky.graph.defs#starterPackViewBasic)
         /// </summary>
         [JsonPropertyName("joinedViaStarterPack")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Graph.StarterPackViewBasic? JoinedViaStarterPack { get; set; }
 
         /// <summary>
         /// Gets or sets the indexedAt.
         /// </summary>
         [JsonPropertyName("indexedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? IndexedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -191,12 +202,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ViewerState"/> (app.bsky.actor.defs#viewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ViewerState? Viewer { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -204,6 +217,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("pinnedPost")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? PinnedPost { get; set; }
 
         /// <summary>
@@ -211,6 +225,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.VerificationState"/> (app.bsky.actor.defs#verificationState)
         /// </summary>
         [JsonPropertyName("verification")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.VerificationState? Verification { get; set; }
 
         /// <summary>
@@ -218,6 +233,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.StatusView"/> (app.bsky.actor.defs#statusView)
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.StatusView? Status { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#profileViewDetailed";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/SavedFeedsPref.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/SavedFeedsPref.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the timelineIndex.
         /// </summary>
         [JsonPropertyName("timelineIndex")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? TimelineIndex { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#savedFeedsPref";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/SearchActorsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/SearchActorsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/Status.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/Status.g.cs
@@ -64,6 +64,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// live - Advertises an account as currently offering live content. <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? StatusValue { get; set; }
 
         /// <summary>
@@ -73,6 +74,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Embed.EmbedExternal"/> (app.bsky.embed.external) <br/>
         /// </summary>
         [JsonPropertyName("embed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.EmbedExternal? Embed { get; set; }
 
         /// <summary>
@@ -80,12 +82,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> The duration of the status in minutes. Applications can choose to impose minimum and maximum limits.
         /// </summary>
         [JsonPropertyName("durationMinutes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? DurationMinutes { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.actor.status";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/StatusView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/StatusView.g.cs
@@ -81,6 +81,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Embed.ViewExternal"/> (app.bsky.embed.external#view) <br/>
         /// </summary>
         [JsonPropertyName("embed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.ViewExternal? Embed { get; set; }
 
         /// <summary>
@@ -88,6 +89,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> The date when this status will expire. The application might choose to no longer return the status after expiration.
         /// </summary>
         [JsonPropertyName("expiresAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
@@ -95,6 +97,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> True if the status is not expired, false if it is expired. Only present if expiration was set.
         /// </summary>
         [JsonPropertyName("isActive")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IsActive { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#statusView";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ThreadViewPref.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ThreadViewPref.g.cs
@@ -60,6 +60,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// hotness <br/>
         /// </summary>
         [JsonPropertyName("sort")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Sort { get; set; }
 
         /// <summary>
@@ -67,6 +68,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Show followed users at the top of all replies.
         /// </summary>
         [JsonPropertyName("prioritizeFollowedUsers")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? PrioritizeFollowedUsers { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#threadViewPref";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/VerificationPrefs.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/VerificationPrefs.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> Hide the blue check badges for verified accounts and trusted verifiers.
         /// </summary>
         [JsonPropertyName("hideBadges")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? HideBadges { get; set; } = false;
 
         public const string RecordType = "app.bsky.actor.defs#verificationPrefs";

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ViewerState.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ViewerState.g.cs
@@ -73,6 +73,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the muted.
         /// </summary>
         [JsonPropertyName("muted")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Muted { get; set; }
 
         /// <summary>
@@ -80,18 +81,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Graph.ListViewBasic"/> (app.bsky.graph.defs#listViewBasic)
         /// </summary>
         [JsonPropertyName("mutedByList")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Graph.ListViewBasic? MutedByList { get; set; }
 
         /// <summary>
         /// Gets or sets the blockedBy.
         /// </summary>
         [JsonPropertyName("blockedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? BlockedBy { get; set; }
 
         /// <summary>
         /// Gets or sets the blocking.
         /// </summary>
         [JsonPropertyName("blocking")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Blocking { get; set; }
 
@@ -100,12 +104,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Graph.ListViewBasic"/> (app.bsky.graph.defs#listViewBasic)
         /// </summary>
         [JsonPropertyName("blockingByList")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Graph.ListViewBasic? BlockingByList { get; set; }
 
         /// <summary>
         /// Gets or sets the following.
         /// </summary>
         [JsonPropertyName("following")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Following { get; set; }
 
@@ -113,6 +119,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// Gets or sets the followedBy.
         /// </summary>
         [JsonPropertyName("followedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? FollowedBy { get; set; }
 
@@ -121,6 +128,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.KnownFollowers"/> (app.bsky.actor.defs#knownFollowers)
         /// </summary>
         [JsonPropertyName("knownFollowers")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.KnownFollowers? KnownFollowers { get; set; }
 
         public const string RecordType = "app.bsky.actor.defs#viewerState";

--- a/src/FishyFlip/Lexicon/App/Bsky/Embed/EmbedVideo.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Embed/EmbedVideo.g.cs
@@ -62,6 +62,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// Gets or sets the captions.
         /// </summary>
         [JsonPropertyName("captions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Embed.Caption>? Captions { get; set; }
 
         /// <summary>
@@ -69,6 +70,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// <br/> Alt text description of the video, for accessibility.
         /// </summary>
         [JsonPropertyName("alt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Alt { get; set; }
 
         /// <summary>
@@ -76,6 +78,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio"/> (app.bsky.embed.defs#aspectRatio)
         /// </summary>
         [JsonPropertyName("aspectRatio")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio? AspectRatio { get; set; }
 
         public const string RecordType = "app.bsky.embed.video";

--- a/src/FishyFlip/Lexicon/App/Bsky/Embed/External.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Embed/External.g.cs
@@ -73,6 +73,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// Gets or sets the thumb.
         /// </summary>
         [JsonPropertyName("thumb")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Thumb { get; set; }
 
         public const string RecordType = "app.bsky.embed.external#external";

--- a/src/FishyFlip/Lexicon/App/Bsky/Embed/Image.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Embed/Image.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio"/> (app.bsky.embed.defs#aspectRatio)
         /// </summary>
         [JsonPropertyName("aspectRatio")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio? AspectRatio { get; set; }
 
         public const string RecordType = "app.bsky.embed.images#image";

--- a/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewExternalExternal.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewExternalExternal.g.cs
@@ -73,6 +73,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// Gets or sets the thumb.
         /// </summary>
         [JsonPropertyName("thumb")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Thumb { get; set; }
 
         public const string RecordType = "app.bsky.embed.external#viewExternal";

--- a/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewImage.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewImage.g.cs
@@ -79,6 +79,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio"/> (app.bsky.embed.defs#aspectRatio)
         /// </summary>
         [JsonPropertyName("aspectRatio")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio? AspectRatio { get; set; }
 
         public const string RecordType = "app.bsky.embed.images#viewImage";

--- a/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewRecord.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewRecord.g.cs
@@ -113,30 +113,35 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
         /// Gets or sets the replyCount.
         /// </summary>
         [JsonPropertyName("replyCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ReplyCount { get; set; }
 
         /// <summary>
         /// Gets or sets the repostCount.
         /// </summary>
         [JsonPropertyName("repostCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RepostCount { get; set; }
 
         /// <summary>
         /// Gets or sets the likeCount.
         /// </summary>
         [JsonPropertyName("likeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? LikeCount { get; set; }
 
         /// <summary>
         /// Gets or sets the quoteCount.
         /// </summary>
         [JsonPropertyName("quoteCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? QuoteCount { get; set; }
 
         /// <summary>
@@ -149,6 +154,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Embed.ViewRecordWithMedia"/> (app.bsky.embed.recordWithMedia#view) <br/>
         /// </summary>
         [JsonPropertyName("embeds")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<ATObject>? Embeds { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewVideo.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Embed/ViewVideo.g.cs
@@ -71,12 +71,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// Gets or sets the thumbnail.
         /// </summary>
         [JsonPropertyName("thumbnail")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Thumbnail { get; set; }
 
         /// <summary>
         /// Gets or sets the alt.
         /// </summary>
         [JsonPropertyName("alt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Alt { get; set; }
 
         /// <summary>
@@ -84,6 +86,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Embed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio"/> (app.bsky.embed.defs#aspectRatio)
         /// </summary>
         [JsonPropertyName("aspectRatio")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.AspectRatio? AspectRatio { get; set; }
 
         public const string RecordType = "app.bsky.embed.video#view";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/BlockedAuthor.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/BlockedAuthor.g.cs
@@ -57,6 +57,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ViewerState"/> (app.bsky.actor.defs#viewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ViewerState? Viewer { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#blockedAuthor";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/DescribeFeedGeneratorOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/DescribeFeedGeneratorOutput.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// app.bsky.feed.defs#links <br/>
         /// </summary>
         [JsonPropertyName("links")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.Links? Links { get; set; }
 
         public const string RecordType = "app.bsky.feed.describeFeedGenerator#DescribeFeedGeneratorOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedViewPost.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedViewPost.g.cs
@@ -69,6 +69,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ReplyRef"/> (app.bsky.feed.defs#replyRef)
         /// </summary>
         [JsonPropertyName("reply")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.ReplyRef? Reply { get; set; }
 
         /// <summary>
@@ -78,6 +79,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ReasonPin"/> (app.bsky.feed.defs#reasonPin) <br/>
         /// </summary>
         [JsonPropertyName("reason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Reason { get; set; }
 
         /// <summary>
@@ -85,6 +87,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Context provided by feed generator that may be passed back alongside interactions.
         /// </summary>
         [JsonPropertyName("feedContext")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? FeedContext { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#feedViewPost";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Generator.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Generator.g.cs
@@ -77,6 +77,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the did.
         /// </summary>
         [JsonPropertyName("did")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Did { get; set; }
 
@@ -84,24 +85,28 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Avatar { get; set; }
 
         /// <summary>
@@ -109,6 +114,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Declaration that a feed accepts feedback interactions from a client through app.bsky.feed.sendInteractions
         /// </summary>
         [JsonPropertyName("acceptsInteractions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AcceptsInteractions { get; set; }
 
         /// <summary>
@@ -118,6 +124,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         /// <summary>
@@ -127,12 +134,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// contentModeVideo - Declares the feed generator returns posts containing app.bsky.embed.video embeds. <br/>
         /// </summary>
         [JsonPropertyName("contentMode")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ContentMode { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.feed.generator";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GeneratorView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GeneratorView.g.cs
@@ -128,36 +128,42 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the likeCount.
         /// </summary>
         [JsonPropertyName("likeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? LikeCount { get; set; }
 
         /// <summary>
         /// Gets or sets the acceptsInteractions.
         /// </summary>
         [JsonPropertyName("acceptsInteractions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AcceptsInteractions { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -165,6 +171,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GeneratorViewerState"/> (app.bsky.feed.defs#generatorViewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.GeneratorViewerState? Viewer { get; set; }
 
         /// <summary>
@@ -174,6 +181,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// contentModeVideo - Declares the feed generator returns posts containing app.bsky.embed.video embeds. <br/>
         /// </summary>
         [JsonPropertyName("contentMode")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ContentMode { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GeneratorViewerState.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GeneratorViewerState.g.cs
@@ -43,6 +43,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the like.
         /// </summary>
         [JsonPropertyName("like")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Like { get; set; }
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetActorFeedsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetActorFeedsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetActorLikesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetActorLikesOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetAuthorFeedOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetAuthorFeedOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetFeedOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetFeedOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetFeedSkeletonOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetFeedSkeletonOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetLikesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetLikesOutput.g.cs
@@ -60,12 +60,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetListFeedOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetListFeedOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetPostThreadOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetPostThreadOutput.g.cs
@@ -65,6 +65,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ThreadgateView"/> (app.bsky.feed.defs#threadgateView)
         /// </summary>
         [JsonPropertyName("threadgate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.ThreadgateView? Threadgate { get; set; }
 
         public const string RecordType = "app.bsky.feed.getPostThread#GetPostThreadOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetQuotesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetQuotesOutput.g.cs
@@ -60,12 +60,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetRepostedByOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetRepostedByOutput.g.cs
@@ -60,12 +60,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetSuggestedFeedsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetSuggestedFeedsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/GetTimelineOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/GetTimelineOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Interaction.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Interaction.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the item.
         /// </summary>
         [JsonPropertyName("item")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Item { get; set; }
 
@@ -83,6 +84,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// interactionShare - User shared the feed item <br/>
         /// </summary>
         [JsonPropertyName("event")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Event { get; set; }
 
         /// <summary>
@@ -90,6 +92,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.
         /// </summary>
         [JsonPropertyName("feedContext")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? FeedContext { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#interaction";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Like.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Like.g.cs
@@ -52,12 +52,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Subject { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.feed.like";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Links.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Links.g.cs
@@ -46,12 +46,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the privacyPolicy.
         /// </summary>
         [JsonPropertyName("privacyPolicy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? PrivacyPolicy { get; set; }
 
         /// <summary>
         /// Gets or sets the termsOfService.
         /// </summary>
         [JsonPropertyName("termsOfService")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? TermsOfService { get; set; }
 
         public const string RecordType = "app.bsky.feed.describeFeedGenerator#links";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Post.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Post.g.cs
@@ -80,6 +80,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> The primary post content. May be an empty string, if there are embeds.
         /// </summary>
         [JsonPropertyName("text")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Text { get; set; }
 
         /// <summary>
@@ -87,6 +88,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Annotations of text (mentions, URLs, hashtags, etc)
         /// </summary>
         [JsonPropertyName("facets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? Facets { get; set; }
 
         /// <summary>
@@ -94,6 +96,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ReplyRef"/> (app.bsky.feed.defs#replyRef)
         /// </summary>
         [JsonPropertyName("reply")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.ReplyRefDef? Reply { get; set; }
 
         /// <summary>
@@ -106,6 +109,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Embed.RecordWithMedia"/> (app.bsky.embed.recordWithMedia) <br/>
         /// </summary>
         [JsonPropertyName("embed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Embed { get; set; }
 
         /// <summary>
@@ -113,6 +117,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Indicates human language of post primary text content.
         /// </summary>
         [JsonPropertyName("langs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Langs { get; set; }
 
         /// <summary>
@@ -122,6 +127,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         /// <summary>
@@ -129,6 +135,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Additional hashtags, in addition to any included in post text and facets.
         /// </summary>
         [JsonPropertyName("tags")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Tags { get; set; }
 
         /// <summary>
@@ -136,6 +143,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Client-declared timestamp when this post was originally created.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.feed.post";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/PostView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/PostView.g.cs
@@ -128,30 +128,35 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Embed.ViewRecordWithMedia"/> (app.bsky.embed.recordWithMedia#view) <br/>
         /// </summary>
         [JsonPropertyName("embed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Embed { get; set; }
 
         /// <summary>
         /// Gets or sets the replyCount.
         /// </summary>
         [JsonPropertyName("replyCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ReplyCount { get; set; }
 
         /// <summary>
         /// Gets or sets the repostCount.
         /// </summary>
         [JsonPropertyName("repostCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RepostCount { get; set; }
 
         /// <summary>
         /// Gets or sets the likeCount.
         /// </summary>
         [JsonPropertyName("likeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? LikeCount { get; set; }
 
         /// <summary>
         /// Gets or sets the quoteCount.
         /// </summary>
         [JsonPropertyName("quoteCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? QuoteCount { get; set; }
 
         /// <summary>
@@ -166,12 +171,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ViewerState"/> (app.bsky.feed.defs#viewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.ViewerState? Viewer { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -179,6 +186,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ThreadgateView"/> (app.bsky.feed.defs#threadgateView)
         /// </summary>
         [JsonPropertyName("threadgate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.ThreadgateView? Threadgate { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#postView";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Postgate.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Postgate.g.cs
@@ -58,6 +58,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -65,6 +66,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Reference (AT-URI) to the post record.
         /// </summary>
         [JsonPropertyName("post")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Post { get; set; }
 
@@ -73,6 +75,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> List of AT-URIs embedding this post that the author has detached from.
         /// </summary>
         [JsonPropertyName("detachedEmbeddingUris")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Models.ATUri>? DetachedEmbeddingUris { get; set; }
 
         /// <summary>
@@ -82,6 +85,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.DisableRule"/> (app.bsky.feed.postgate#disableRule) <br/>
         /// </summary>
         [JsonPropertyName("embeddingRules")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Feed.DisableRule>? EmbeddingRules { get; set; }
 
         public const string RecordType = "app.bsky.feed.postgate";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/ReplyRef.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/ReplyRef.g.cs
@@ -85,6 +85,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewBasic"/> (app.bsky.actor.defs#profileViewBasic)
         /// </summary>
         [JsonPropertyName("grandparentAuthor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewBasic? GrandparentAuthor { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#replyRef";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Repost.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Repost.g.cs
@@ -52,12 +52,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Subject { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.feed.repost";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/SearchPostsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/SearchPostsOutput.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>
@@ -56,6 +57,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Count of search hits. Optional, may be rounded/truncated, and may not be possible to paginate through all hits.
         /// </summary>
         [JsonPropertyName("hitsTotal")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? HitsTotal { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/SkeletonFeedPost.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/SkeletonFeedPost.g.cs
@@ -64,6 +64,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.SkeletonReasonPin"/> (app.bsky.feed.defs#skeletonReasonPin) <br/>
         /// </summary>
         [JsonPropertyName("reason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Reason { get; set; }
 
         /// <summary>
@@ -71,6 +72,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Context that will be passed through to client and may be passed to feed generator back alongside interactions.
         /// </summary>
         [JsonPropertyName("feedContext")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? FeedContext { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#skeletonFeedPost";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/ThreadContext.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/ThreadContext.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the rootAuthorLike.
         /// </summary>
         [JsonPropertyName("rootAuthorLike")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? RootAuthorLike { get; set; }
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/ThreadViewPost.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/ThreadViewPost.g.cs
@@ -78,6 +78,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.BlockedPost"/> (app.bsky.feed.defs#blockedPost) <br/>
         /// </summary>
         [JsonPropertyName("parent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Parent { get; set; }
 
         /// <summary>
@@ -88,6 +89,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.BlockedPost"/> (app.bsky.feed.defs#blockedPost) <br/>
         /// </summary>
         [JsonPropertyName("replies")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<ATObject>? Replies { get; set; }
 
         /// <summary>
@@ -95,6 +97,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ThreadContext"/> (app.bsky.feed.defs#threadContext)
         /// </summary>
         [JsonPropertyName("threadContext")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Feed.ThreadContext? ThreadContext { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#threadViewPost";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/Threadgate.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/Threadgate.g.cs
@@ -62,6 +62,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> Reference (AT-URI) to the post record.
         /// </summary>
         [JsonPropertyName("post")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Post { get; set; }
 
@@ -75,12 +76,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Feed.ListRule"/> (app.bsky.feed.threadgate#listRule) <br/>
         /// </summary>
         [JsonPropertyName("allow")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<ATObject>? Allow { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -88,6 +91,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// <br/> List of hidden reply URIs.
         /// </summary>
         [JsonPropertyName("hiddenReplies")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Models.ATUri>? HiddenReplies { get; set; }
 
         public const string RecordType = "app.bsky.feed.threadgate";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/ThreadgateView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/ThreadgateView.g.cs
@@ -52,6 +52,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the uri.
         /// </summary>
         [JsonPropertyName("uri")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Uri { get; set; }
 
@@ -59,18 +60,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>
         /// Gets or sets the record.
         /// </summary>
         [JsonPropertyName("record")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Record { get; set; }
 
         /// <summary>
         /// Gets or sets the lists.
         /// </summary>
         [JsonPropertyName("lists")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Graph.ListViewBasic>? Lists { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#threadgateView";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/ViewerState.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/ViewerState.g.cs
@@ -61,6 +61,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the repost.
         /// </summary>
         [JsonPropertyName("repost")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Repost { get; set; }
 
@@ -68,6 +69,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the like.
         /// </summary>
         [JsonPropertyName("like")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Like { get; set; }
 
@@ -75,24 +77,28 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
         /// Gets or sets the threadMuted.
         /// </summary>
         [JsonPropertyName("threadMuted")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? ThreadMuted { get; set; }
 
         /// <summary>
         /// Gets or sets the replyDisabled.
         /// </summary>
         [JsonPropertyName("replyDisabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? ReplyDisabled { get; set; }
 
         /// <summary>
         /// Gets or sets the embeddingDisabled.
         /// </summary>
         [JsonPropertyName("embeddingDisabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? EmbeddingDisabled { get; set; }
 
         /// <summary>
         /// Gets or sets the pinned.
         /// </summary>
         [JsonPropertyName("pinned")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Pinned { get; set; }
 
         public const string RecordType = "app.bsky.feed.defs#viewerState";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/Block.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/Block.g.cs
@@ -50,6 +50,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> DID of the account to be blocked.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Subject { get; set; }
 
@@ -57,6 +58,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.graph.block";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/Follow.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/Follow.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the subject.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Subject { get; set; }
 
@@ -56,6 +57,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.graph.follow";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetActorStarterPacksOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetActorStarterPacksOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetBlocksOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetBlocksOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetFollowersOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetFollowersOutput.g.cs
@@ -59,6 +59,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetFollowsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetFollowsOutput.g.cs
@@ -59,6 +59,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetKnownFollowersOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetKnownFollowersOutput.g.cs
@@ -59,6 +59,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListBlocksOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListBlocksOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListMutesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListMutesOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListOutput.g.cs
@@ -51,6 +51,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetListsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetMutesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetMutesOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetRelationshipsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetRelationshipsOutput.g.cs
@@ -50,6 +50,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the actor.
         /// </summary>
         [JsonPropertyName("actor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Actor { get; set; }
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GetSuggestedFollowsByActorOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GetSuggestedFollowsByActorOutput.g.cs
@@ -57,6 +57,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> If true, response has fallen-back to generic results, and is not scoped using relativeToDid
         /// </summary>
         [JsonPropertyName("isFallback")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IsFallback { get; set; } = false;
 
         /// <summary>
@@ -64,6 +65,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Snowflake for this recommendation, use when submitting recommendation events.
         /// </summary>
         [JsonPropertyName("recId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RecId { get; set; }
 
         public const string RecordType = "app.bsky.graph.getSuggestedFollowsByActor#GetSuggestedFollowsByActorOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/List.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/List.g.cs
@@ -77,6 +77,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// app.bsky.graph.defs#referencelist - A list of actors used for only for reference purposes such as within a starter pack. <br/>
         /// </summary>
         [JsonPropertyName("purpose")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Purpose { get; set; }
 
         /// <summary>
@@ -84,24 +85,28 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Display name for list; can not be empty.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Avatar { get; set; }
 
         /// <summary>
@@ -110,12 +115,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.graph.list";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/ListView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/ListView.g.cs
@@ -126,30 +126,35 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the listItemCount.
         /// </summary>
         [JsonPropertyName("listItemCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ListItemCount { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -157,6 +162,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Graph.ListViewerState"/> (app.bsky.graph.defs#listViewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Graph.ListViewerState? Viewer { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/ListViewBasic.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/ListViewBasic.g.cs
@@ -107,18 +107,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the listItemCount.
         /// </summary>
         [JsonPropertyName("listItemCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ListItemCount { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -126,12 +129,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Graph.ListViewerState"/> (app.bsky.graph.defs#listViewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Graph.ListViewerState? Viewer { get; set; }
 
         /// <summary>
         /// Gets or sets the indexedAt.
         /// </summary>
         [JsonPropertyName("indexedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? IndexedAt { get; set; }
 
         public const string RecordType = "app.bsky.graph.defs#listViewBasic";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/ListViewerState.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/ListViewerState.g.cs
@@ -46,12 +46,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the muted.
         /// </summary>
         [JsonPropertyName("muted")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Muted { get; set; }
 
         /// <summary>
         /// Gets or sets the blocked.
         /// </summary>
         [JsonPropertyName("blocked")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Blocked { get; set; }
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/Listblock.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/Listblock.g.cs
@@ -50,6 +50,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Reference (AT-URI) to the mod list record.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Subject { get; set; }
 
@@ -57,6 +58,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.graph.listblock";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/Listitem.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/Listitem.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> The account which is included on the list.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Subject { get; set; }
 
@@ -61,6 +62,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Reference (AT-URI) to the list record (app.bsky.graph.list).
         /// </summary>
         [JsonPropertyName("list")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? List { get; set; }
 
@@ -68,6 +70,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.graph.listitem";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/Relationship.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/Relationship.g.cs
@@ -61,6 +61,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> if the actor follows this DID, this is the AT-URI of the follow record
         /// </summary>
         [JsonPropertyName("following")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Following { get; set; }
 
@@ -69,6 +70,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> if the actor is followed by this DID, contains the AT-URI of the follow record
         /// </summary>
         [JsonPropertyName("followedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? FollowedBy { get; set; }
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/SearchStarterPacksOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/SearchStarterPacksOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/StarterPackView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/StarterPackView.g.cs
@@ -108,36 +108,42 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Graph.ListViewBasic"/> (app.bsky.graph.defs#listViewBasic)
         /// </summary>
         [JsonPropertyName("list")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Graph.ListViewBasic? List { get; set; }
 
         /// <summary>
         /// Gets or sets the listItemsSample.
         /// </summary>
         [JsonPropertyName("listItemsSample")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Graph.ListItemView>? ListItemsSample { get; set; }
 
         /// <summary>
         /// Gets or sets the feeds.
         /// </summary>
         [JsonPropertyName("feeds")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Feed.GeneratorView>? Feeds { get; set; }
 
         /// <summary>
         /// Gets or sets the joinedWeekCount.
         /// </summary>
         [JsonPropertyName("joinedWeekCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? JoinedWeekCount { get; set; }
 
         /// <summary>
         /// Gets or sets the joinedAllTimeCount.
         /// </summary>
         [JsonPropertyName("joinedAllTimeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? JoinedAllTimeCount { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/StarterPackViewBasic.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/StarterPackViewBasic.g.cs
@@ -99,24 +99,28 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the listItemCount.
         /// </summary>
         [JsonPropertyName("listItemCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ListItemCount { get; set; }
 
         /// <summary>
         /// Gets or sets the joinedWeekCount.
         /// </summary>
         [JsonPropertyName("joinedWeekCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? JoinedWeekCount { get; set; }
 
         /// <summary>
         /// Gets or sets the joinedAllTimeCount.
         /// </summary>
         [JsonPropertyName("joinedAllTimeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? JoinedAllTimeCount { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/Starterpack.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/Starterpack.g.cs
@@ -62,18 +62,21 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Display name for starter pack; can not be empty.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
@@ -81,6 +84,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Reference (AT-URI) to the list record.
         /// </summary>
         [JsonPropertyName("list")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? List { get; set; }
 
@@ -88,12 +92,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// Gets or sets the feeds.
         /// </summary>
         [JsonPropertyName("feeds")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Graph.FeedItem>? Feeds { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.graph.starterpack";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/Verification.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/Verification.g.cs
@@ -56,6 +56,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> DID of the subject the verification applies to.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Subject { get; set; }
 
@@ -64,6 +65,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Handle of the subject the verification applies to at the moment of verifying, which might not be the same at the time of viewing. The verification is only valid if the current handle matches the one at the time of verifying.
         /// </summary>
         [JsonPropertyName("handle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATHandleJsonConverter))]
         public FishyFlip.Models.ATHandle? Handle { get; set; }
 
@@ -72,6 +74,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Display name of the subject the verification applies to at the moment of verifying, which might not be the same at the time of viewing. The verification is only valid if the current displayName matches the one at the time of verifying.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
@@ -79,6 +82,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
         /// <br/> Date of when the verification was created.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "app.bsky.graph.verification";

--- a/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerPolicies.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerPolicies.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> Label values created by this labeler and scoped exclusively to it. Labels defined here will override global label definitions for this labeler.
         /// </summary>
         [JsonPropertyName("labelValueDefinitions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.LabelValueDefinition>? LabelValueDefinitions { get; set; }
 
         public const string RecordType = "app.bsky.labeler.defs#labelerPolicies";

--- a/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerView.g.cs
@@ -88,6 +88,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// Gets or sets the likeCount.
         /// </summary>
         [JsonPropertyName("likeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? LikeCount { get; set; }
 
         /// <summary>
@@ -95,6 +96,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Labeler.LabelerViewerState"/> (app.bsky.labeler.defs#labelerViewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Labeler.LabelerViewerState? Viewer { get; set; }
 
         /// <summary>
@@ -108,6 +110,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         public const string RecordType = "app.bsky.labeler.defs#labelerView";

--- a/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerViewDetailed.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerViewDetailed.g.cs
@@ -110,6 +110,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// Gets or sets the likeCount.
         /// </summary>
         [JsonPropertyName("likeCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? LikeCount { get; set; }
 
         /// <summary>
@@ -117,6 +118,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Labeler.LabelerViewerState"/> (app.bsky.labeler.defs#labelerViewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Labeler.LabelerViewerState? Viewer { get; set; }
 
         /// <summary>
@@ -130,6 +132,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -137,6 +140,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> The set of report reason 'codes' which are in-scope for this service to review and action. These usually align to policy categories. If not defined (distinct from empty array), all reason types are allowed.
         /// </summary>
         [JsonPropertyName("reasonTypes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? ReasonTypes { get; set; }
 
         /// <summary>
@@ -144,6 +148,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> The set of subject types (account, record, etc) this service accepts reports on.
         /// </summary>
         [JsonPropertyName("subjectTypes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? SubjectTypes { get; set; }
 
         /// <summary>
@@ -151,6 +156,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> Set of record types (collection NSIDs) which can be reported to this service. If not defined (distinct from empty array), default is any record type.
         /// </summary>
         [JsonPropertyName("subjectCollections")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? SubjectCollections { get; set; }
 
         public const string RecordType = "app.bsky.labeler.defs#labelerViewDetailed";

--- a/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerViewerState.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerViewerState.g.cs
@@ -43,6 +43,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// Gets or sets the like.
         /// </summary>
         [JsonPropertyName("like")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Like { get; set; }
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Labeler/Service.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Labeler/Service.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Labeler.LabelerPolicies"/> (app.bsky.labeler.defs#labelerPolicies)
         /// </summary>
         [JsonPropertyName("policies")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Labeler.LabelerPolicies? Policies { get; set; }
 
         /// <summary>
@@ -75,12 +76,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -88,6 +91,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> The set of report reason 'codes' which are in-scope for this service to review and action. These usually align to policy categories. If not defined (distinct from empty array), all reason types are allowed.
         /// </summary>
         [JsonPropertyName("reasonTypes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? ReasonTypes { get; set; }
 
         /// <summary>
@@ -95,6 +99,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> The set of subject types (account, record, etc) this service accepts reports on.
         /// </summary>
         [JsonPropertyName("subjectTypes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? SubjectTypes { get; set; }
 
         /// <summary>
@@ -102,6 +107,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
         /// <br/> Set of record types (collection NSIDs) which can be reported to this service. If not defined (distinct from empty array), default is any record type.
         /// </summary>
         [JsonPropertyName("subjectCollections")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? SubjectCollections { get; set; }
 
         public const string RecordType = "app.bsky.labeler.service";

--- a/src/FishyFlip/Lexicon/App/Bsky/Notification/ListNotificationsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Notification/ListNotificationsOutput.g.cs
@@ -52,6 +52,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>
@@ -65,12 +66,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
         /// Gets or sets the priority.
         /// </summary>
         [JsonPropertyName("priority")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Priority { get; set; }
 
         /// <summary>
         /// Gets or sets the seenAt.
         /// </summary>
         [JsonPropertyName("seenAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? SeenAt { get; set; }
 
         public const string RecordType = "app.bsky.notification.listNotifications#ListNotificationsOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Notification/Notification.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Notification/Notification.g.cs
@@ -121,6 +121,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
         /// Gets or sets the reasonSubject.
         /// </summary>
         [JsonPropertyName("reasonSubject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? ReasonSubject { get; set; }
 
@@ -149,6 +150,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         public const string RecordType = "app.bsky.notification.listNotifications#notification";

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/GetConfigOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/GetConfigOutput.g.cs
@@ -43,6 +43,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// Gets or sets the checkEmailConfirmed.
         /// </summary>
         [JsonPropertyName("checkEmailConfirmed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? CheckEmailConfirmed { get; set; }
 
         public const string RecordType = "app.bsky.unspecced.getConfig#GetConfigOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/GetPopularFeedGeneratorsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/GetPopularFeedGeneratorsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/GetSuggestionsSkeletonOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/GetSuggestionsSkeletonOutput.g.cs
@@ -52,6 +52,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>
@@ -66,6 +67,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// <br/> DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer.
         /// </summary>
         [JsonPropertyName("relativeToDid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? RelativeToDid { get; set; }
 
@@ -74,6 +76,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// <br/> Snowflake for this recommendation, use when submitting recommendation events.
         /// </summary>
         [JsonPropertyName("recId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RecId { get; set; }
 
         public const string RecordType = "app.bsky.unspecced.getSuggestionsSkeleton#GetSuggestionsSkeletonOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SearchActorsSkeletonOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SearchActorsSkeletonOutput.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>
@@ -56,6 +57,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// <br/> Count of search hits. Optional, may be rounded/truncated, and may not be possible to paginate through all hits.
         /// </summary>
         [JsonPropertyName("hitsTotal")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? HitsTotal { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SearchPostsSkeletonOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SearchPostsSkeletonOutput.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>
@@ -56,6 +57,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// <br/> Count of search hits. Optional, may be rounded/truncated, and may not be possible to paginate through all hits.
         /// </summary>
         [JsonPropertyName("hitsTotal")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? HitsTotal { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SearchStarterPacksSkeletonOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SearchStarterPacksSkeletonOutput.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>
@@ -56,6 +57,7 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// <br/> Count of search hits. Optional, may be rounded/truncated, and may not be possible to paginate through all hits.
         /// </summary>
         [JsonPropertyName("hitsTotal")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? HitsTotal { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SkeletonTrend.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/SkeletonTrend.g.cs
@@ -104,12 +104,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// hot <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>
         /// Gets or sets the category.
         /// </summary>
         [JsonPropertyName("category")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Category { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/TrendView.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/TrendView.g.cs
@@ -104,12 +104,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// hot <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>
         /// Gets or sets the category.
         /// </summary>
         [JsonPropertyName("category")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Category { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/TrendingTopic.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/TrendingTopic.g.cs
@@ -59,12 +59,14 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/App/Bsky/Video/GetUploadLimitsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Video/GetUploadLimitsOutput.g.cs
@@ -62,24 +62,28 @@ namespace FishyFlip.Lexicon.App.Bsky.Video
         /// Gets or sets the remainingDailyVideos.
         /// </summary>
         [JsonPropertyName("remainingDailyVideos")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RemainingDailyVideos { get; set; }
 
         /// <summary>
         /// Gets or sets the remainingDailyBytes.
         /// </summary>
         [JsonPropertyName("remainingDailyBytes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RemainingDailyBytes { get; set; }
 
         /// <summary>
         /// Gets or sets the message.
         /// </summary>
         [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Message { get; set; }
 
         /// <summary>
         /// Gets or sets the error.
         /// </summary>
         [JsonPropertyName("error")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Error { get; set; }
 
         public const string RecordType = "app.bsky.video.getUploadLimits#GetUploadLimitsOutput";

--- a/src/FishyFlip/Lexicon/App/Bsky/Video/JobStatus.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Video/JobStatus.g.cs
@@ -92,24 +92,28 @@ namespace FishyFlip.Lexicon.App.Bsky.Video
         /// <br/> Progress within the current processing state.
         /// </summary>
         [JsonPropertyName("progress")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Progress { get; set; }
 
         /// <summary>
         /// Gets or sets the blob.
         /// </summary>
         [JsonPropertyName("blob")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Blob { get; set; }
 
         /// <summary>
         /// Gets or sets the error.
         /// </summary>
         [JsonPropertyName("error")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Error { get; set; }
 
         /// <summary>
         /// Gets or sets the message.
         /// </summary>
         [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Message { get; set; }
 
         public const string RecordType = "app.bsky.video.defs#jobStatus";

--- a/src/FishyFlip/Lexicon/App/Netlify/Aniblue/Status.g.cs
+++ b/src/FishyFlip/Lexicon/App/Netlify/Aniblue/Status.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.App.Netlify.Aniblue
         /// Gets or sets the status.
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Netlify.Aniblue.StatusDef>? StatusValue { get; set; }
 
         public const string RecordType = "app.netlify.aniblue.status";

--- a/src/FishyFlip/Lexicon/App/Netlify/Aniblue/StatusDef.g.cs
+++ b/src/FishyFlip/Lexicon/App/Netlify/Aniblue/StatusDef.g.cs
@@ -75,6 +75,7 @@ namespace FishyFlip.Lexicon.App.Netlify.Aniblue
         /// <br/> URL of the anime thumbnail image
         /// </summary>
         [JsonPropertyName("thumbnail")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Thumbnail { get; set; }
 
         /// <summary>
@@ -98,6 +99,7 @@ namespace FishyFlip.Lexicon.App.Netlify.Aniblue
         /// <br/> Favorite flag of the anime
         /// </summary>
         [JsonPropertyName("favorite")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Favorite { get; set; }
 
         public const string RecordType = "app.netlify.aniblue.status#status";

--- a/src/FishyFlip/Lexicon/Blue/Linkat/Board.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Linkat/Board.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Blue.Linkat
         /// <br/> List of cards in the board.
         /// </summary>
         [JsonPropertyName("cards")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Blue.Linkat.Card>? Cards { get; set; }
 
         public const string RecordType = "blue.linkat.board";

--- a/src/FishyFlip/Lexicon/Blue/Linkat/Card.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Linkat/Card.g.cs
@@ -50,6 +50,7 @@ namespace FishyFlip.Lexicon.Blue.Linkat
         /// <br/> URL of the link
         /// </summary>
         [JsonPropertyName("url")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Url { get; set; }
 
         /// <summary>
@@ -57,6 +58,7 @@ namespace FishyFlip.Lexicon.Blue.Linkat
         /// <br/> Text of the card
         /// </summary>
         [JsonPropertyName("text")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Text { get; set; }
 
         /// <summary>
@@ -64,6 +66,7 @@ namespace FishyFlip.Lexicon.Blue.Linkat
         /// <br/> Emoji of the card
         /// </summary>
         [JsonPropertyName("emoji")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Emoji { get; set; }
 
         public const string RecordType = "blue.linkat.board#card";

--- a/src/FishyFlip/Lexicon/Blue/Maril/Stellar/GetActorReactionsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Maril/Stellar/GetActorReactionsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Maril/Stellar/GetEmojisOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Maril/Stellar/GetEmojisOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Maril/Stellar/GetReactionsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Maril/Stellar/GetReactionsOutput.g.cs
@@ -60,12 +60,14 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Maril/Stellar/Reaction.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Maril/Stellar/Reaction.g.cs
@@ -54,6 +54,7 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Subject { get; set; }
 
         /// <summary>
@@ -61,6 +62,7 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
         /// blue.maril.stellar.defs#emojiRef <br/>
         /// </summary>
         [JsonPropertyName("emoji")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Blue.Maril.Stellar.EmojiRef? Emoji { get; set; }
 
         public const string RecordType = "blue.maril.stellar.reaction";

--- a/src/FishyFlip/Lexicon/Blue/Maril/Stellar/ReactionDef.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Maril/Stellar/ReactionDef.g.cs
@@ -89,6 +89,7 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
         /// <br/> <see cref="FishyFlip.Lexicon.Blue.Maril.Stellar.EmojiRef"/> (blue.maril.stellar.reaction#emojiRef)
         /// </summary>
         [JsonPropertyName("emojiRef")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Blue.Maril.Stellar.EmojiRef? EmojiRef { get; set; }
 
         /// <summary>
@@ -104,6 +105,7 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileView"/> (app.bsky.actor.defs#profileView)
         /// </summary>
         [JsonPropertyName("actor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileView? Actor { get; set; }
 
         public const string RecordType = "blue.maril.stellar.getReactions#reaction";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/CollectionView.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/CollectionView.g.cs
@@ -102,30 +102,35 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the collectionItemCount.
         /// </summary>
         [JsonPropertyName("collectionItemCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? CollectionItemCount { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/FormatsV0.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/FormatsV0.g.cs
@@ -68,6 +68,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// Gets or sets the original.
         /// </summary>
         [JsonPropertyName("original")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Original { get; set; }
 
         /// <summary>
@@ -75,6 +76,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// blue.moji.collection.defs#blob_v0 <br/>
         /// </summary>
         [JsonPropertyName("png_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Png128 { get; set; }
 
         /// <summary>
@@ -82,6 +84,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// blue.moji.collection.defs#bytes_v0 <br/>
         /// </summary>
         [JsonPropertyName("apng_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public byte[]? Apng128 { get; set; }
 
         /// <summary>
@@ -89,6 +92,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// blue.moji.collection.defs#blob_v0 <br/>
         /// </summary>
         [JsonPropertyName("gif_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Gif128 { get; set; }
 
         /// <summary>
@@ -96,6 +100,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// blue.moji.collection.defs#blob_v0 <br/>
         /// </summary>
         [JsonPropertyName("webp_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Webp128 { get; set; }
 
         /// <summary>
@@ -103,6 +108,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// blue.moji.collection.defs#bytes_v0 <br/>
         /// </summary>
         [JsonPropertyName("lottie")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public byte[]? Lottie { get; set; }
 
         public const string RecordType = "blue.moji.collection.item#formats_v0";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/Item.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/Item.g.cs
@@ -74,18 +74,21 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// <br/> Should be in the format :emoji:
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the alt.
         /// </summary>
         [JsonPropertyName("alt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Alt { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -95,12 +98,14 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// <see cref="FishyFlip.Lexicon.Blue.Moji.Collection.FormatsV0"/> (blue.moji.collection.item#formats_v0) <br/>
         /// </summary>
         [JsonPropertyName("formats")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Blue.Moji.Collection.FormatsV0? Formats { get; set; }
 
         /// <summary>
         /// Gets or sets the adultOnly.
         /// </summary>
         [JsonPropertyName("adultOnly")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AdultOnly { get; set; } = false;
 
         /// <summary>
@@ -110,12 +115,14 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         /// <summary>
         /// Gets or sets the copyOf.
         /// </summary>
         [JsonPropertyName("copyOf")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? CopyOf { get; set; }
 
@@ -123,6 +130,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// Gets or sets the fallbackText.
         /// </summary>
         [JsonPropertyName("fallbackText")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? FallbackText { get; set; } = "◌";
 
         public const string RecordType = "blue.moji.collection.item";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/ItemView.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/ItemView.g.cs
@@ -64,12 +64,14 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// Gets or sets the alt.
         /// </summary>
         [JsonPropertyName("alt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Alt { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -84,6 +86,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// Gets or sets the adultOnly.
         /// </summary>
         [JsonPropertyName("adultOnly")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AdultOnly { get; set; } = false;
 
         public const string RecordType = "blue.moji.collection.item#itemView";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/ListCollectionOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/ListCollectionOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/PutItemInput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/PutItemInput.g.cs
@@ -61,6 +61,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// <br/> Can be set to 'false' to skip Lexicon schema validation of record data.
         /// </summary>
         [JsonPropertyName("validate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Validate { get; set; } = true;
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/SaveToCollectionInput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/SaveToCollectionInput.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
         /// <br/> The alias to save the Bluemoji to in the current logged-in user's repo.
         /// </summary>
         [JsonPropertyName("renameTo")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RenameTo { get; set; }
 
         public const string RecordType = "blue.moji.collection.saveToCollection#SaveToCollectionInput";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/GetActorPacksOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/GetActorPacksOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/GetPackOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/GetPackOutput.g.cs
@@ -51,6 +51,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/Pack.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/Pack.g.cs
@@ -67,36 +67,42 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// Gets or sets the name.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Blue.Moji.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the icon.
         /// </summary>
         [JsonPropertyName("icon")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Icon { get; set; }
 
         /// <summary>
         /// Gets or sets the adultOnly.
         /// </summary>
         [JsonPropertyName("adultOnly")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AdultOnly { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -106,6 +112,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         public const string RecordType = "blue.moji.packs.pack";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/PackView.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/PackView.g.cs
@@ -107,30 +107,35 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the packItemCount.
         /// </summary>
         [JsonPropertyName("packItemCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? PackItemCount { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -138,6 +143,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// <br/> <see cref="FishyFlip.Lexicon.Blue.Moji.Packs.PackViewerState"/> (blue.moji.packs.defs#packViewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Blue.Moji.Packs.PackViewerState? Viewer { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/PackViewBasic.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/PackViewBasic.g.cs
@@ -94,30 +94,35 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the descriptionFacets.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Blue.Moji.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the itemCount.
         /// </summary>
         [JsonPropertyName("itemCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ItemCount { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -125,12 +130,14 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// <br/> <see cref="FishyFlip.Lexicon.Blue.Moji.Packs.PackViewerState"/> (blue.moji.packs.defs#packViewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Blue.Moji.Packs.PackViewerState? Viewer { get; set; }
 
         /// <summary>
         /// Gets or sets the indexedAt.
         /// </summary>
         [JsonPropertyName("indexedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? IndexedAt { get; set; }
 
         public const string RecordType = "blue.moji.packs.defs#packViewBasic";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/PackViewerState.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/PackViewerState.g.cs
@@ -43,6 +43,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// Gets or sets the savedToCollection.
         /// </summary>
         [JsonPropertyName("savedToCollection")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? SavedToCollection { get; set; }
 
         public const string RecordType = "blue.moji.packs.defs#packViewerState";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/Packitem.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/Packitem.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// <br/> Reference (AT-URI) to the Bluemoji item record (blue.moji.collection.item).
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Subject { get; set; }
 
@@ -61,6 +62,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// <br/> Reference (AT-URI) to the pack record (blue.moji.packs.pack).
         /// </summary>
         [JsonPropertyName("pack")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Pack { get; set; }
 
@@ -68,6 +70,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "blue.moji.packs.packitem";

--- a/src/FishyFlip/Lexicon/Blue/Moji/Richtext/Facet.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Richtext/Facet.g.cs
@@ -80,12 +80,14 @@ namespace FishyFlip.Lexicon.Blue.Moji.Richtext
         /// Gets or sets the alt.
         /// </summary>
         [JsonPropertyName("alt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Alt { get; set; }
 
         /// <summary>
         /// Gets or sets the adultOnly.
         /// </summary>
         [JsonPropertyName("adultOnly")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AdultOnly { get; set; } = false;
 
         /// <summary>
@@ -95,6 +97,7 @@ namespace FishyFlip.Lexicon.Blue.Moji.Richtext
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels"/> (com.atproto.label.defs#selfLabels) <br/>
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Label.SelfLabels? Labels { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Blue/Moji/Richtext/FormatsV0.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Richtext/FormatsV0.g.cs
@@ -58,30 +58,35 @@ namespace FishyFlip.Lexicon.Blue.Moji.Richtext
         /// Gets or sets the png_128.
         /// </summary>
         [JsonPropertyName("png_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Png128 { get; set; }
 
         /// <summary>
         /// Gets or sets the webp_128.
         /// </summary>
         [JsonPropertyName("webp_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Webp128 { get; set; }
 
         /// <summary>
         /// Gets or sets the gif_128.
         /// </summary>
         [JsonPropertyName("gif_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Gif128 { get; set; }
 
         /// <summary>
         /// Gets or sets the apng_128.
         /// </summary>
         [JsonPropertyName("apng_128")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Apng128 { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the lottie.
         /// </summary>
         [JsonPropertyName("lottie")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Lottie { get; set; } = false;
 
         public const string RecordType = "blue.moji.richtext.facet#formats_v0";

--- a/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Browser.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Browser.g.cs
@@ -49,12 +49,14 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// Gets or sets the id.
         /// </summary>
         [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the userAgent.
         /// </summary>
         [JsonPropertyName("userAgent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? UserAgent { get; set; }
 
         public const string RecordType = "blue.zio.atfile.finger#browser";

--- a/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Lock.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Lock.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// Gets or sets the lock.
         /// </summary>
         [JsonPropertyName("lock")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? LockValue { get; set; }
 
         public const string RecordType = "blue.zio.atfile.lock";

--- a/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Machine.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Machine.g.cs
@@ -55,24 +55,28 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// Gets or sets the app.
         /// </summary>
         [JsonPropertyName("app")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? App { get; set; }
 
         /// <summary>
         /// Gets or sets the host.
         /// </summary>
         [JsonPropertyName("host")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Host { get; set; }
 
         /// <summary>
         /// Gets or sets the id.
         /// </summary>
         [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the os.
         /// </summary>
         [JsonPropertyName("os")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Os { get; set; }
 
         public const string RecordType = "blue.zio.atfile.finger#machine";

--- a/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Unknown.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Unknown.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// Gets or sets the reason.
         /// </summary>
         [JsonPropertyName("reason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Reason { get; set; }
 
         public const string RecordType = "blue.zio.atfile.meta#unknown";

--- a/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Upload.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Zio/Atfile/Upload.g.cs
@@ -68,24 +68,28 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// Gets or sets the blob.
         /// </summary>
         [JsonPropertyName("blob")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Blob { get; set; }
 
         /// <summary>
         /// Gets or sets the checksum.
         /// </summary>
         [JsonPropertyName("checksum")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blue.Zio.Atfile.Checksum? Checksum { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Gets or sets the file.
         /// </summary>
         [JsonPropertyName("file")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blue.Zio.Atfile.File? File { get; set; }
 
         /// <summary>
@@ -95,6 +99,7 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// <see cref="FishyFlip.Lexicon.Blue.Zio.Atfile.Machine"/> (blue.zio.atfile.finger#machine) <br/>
         /// </summary>
         [JsonPropertyName("finger")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Finger { get; set; }
 
         /// <summary>
@@ -103,6 +108,7 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// <see cref="FishyFlip.Lexicon.Blue.Zio.Atfile.Unknown"/> (blue.zio.atfile.meta#unknown) <br/>
         /// </summary>
         [JsonPropertyName("meta")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Blue.Zio.Atfile.Unknown? Meta { get; set; }
 
         public const string RecordType = "blue.zio.atfile.upload";
@@ -155,12 +161,14 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// Gets or sets the algo.
         /// </summary>
         [JsonPropertyName("algo")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Algo { get; set; }
 
         /// <summary>
         /// Gets or sets the hash.
         /// </summary>
         [JsonPropertyName("hash")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Hash { get; set; }
 
     }
@@ -171,24 +179,28 @@ namespace FishyFlip.Lexicon.Blue.Zio.Atfile
         /// Gets or sets the mimeType.
         /// </summary>
         [JsonPropertyName("mimeType")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? MimeType { get; set; }
 
         /// <summary>
         /// Gets or sets the modifiedAt.
         /// </summary>
         [JsonPropertyName("modifiedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? ModifiedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the name.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the size.
         /// </summary>
         [JsonPropertyName("size")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Size { get; set; }
 
     }

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/Book.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/Book.g.cs
@@ -81,6 +81,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The title of the book
         /// </summary>
         [JsonPropertyName("title")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Title { get; set; }
 
         /// <summary>
@@ -88,6 +89,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The authors of the book (tab separated)
         /// </summary>
         [JsonPropertyName("authors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Authors { get; set; }
 
         /// <summary>
@@ -95,12 +97,14 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The book's hive id, used to correlate user's books with the hive
         /// </summary>
         [JsonPropertyName("hiveId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? HiveId { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -108,6 +112,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The date the user started reading the book
         /// </summary>
         [JsonPropertyName("startedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? StartedAt { get; set; }
 
         /// <summary>
@@ -115,6 +120,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The date the user finished reading the book
         /// </summary>
         [JsonPropertyName("finishedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? FinishedAt { get; set; }
 
         /// <summary>
@@ -122,6 +128,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Cover image of the book
         /// </summary>
         [JsonPropertyName("cover")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Cover { get; set; }
 
         /// <summary>
@@ -134,6 +141,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// owned - User owns the book <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>
@@ -141,6 +149,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Number of stars given to the book (1-10) which will be mapped to 1-5 stars
         /// </summary>
         [JsonPropertyName("stars")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Stars { get; set; }
 
         /// <summary>
@@ -148,6 +157,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The book's review
         /// </summary>
         [JsonPropertyName("review")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Review { get; set; }
 
         public const string RecordType = "buzz.bookhive.book";

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/Buzz.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/Buzz.g.cs
@@ -60,6 +60,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The content of the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -67,6 +68,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Client-declared timestamp when this comment was originally created.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -74,6 +76,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("parent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Parent { get; set; }
 
         /// <summary>
@@ -81,6 +84,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("book")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Book { get; set; }
 
         public const string RecordType = "buzz.bookhive.buzz";

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/GetBookOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/GetBookOutput.g.cs
@@ -79,6 +79,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -86,6 +87,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The date the user started reading the book
         /// </summary>
         [JsonPropertyName("startedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? StartedAt { get; set; }
 
         /// <summary>
@@ -93,6 +95,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The date the user finished reading the book
         /// </summary>
         [JsonPropertyName("finishedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? FinishedAt { get; set; }
 
         /// <summary>
@@ -100,6 +103,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Cover image of the book
         /// </summary>
         [JsonPropertyName("cover")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Cover { get; set; }
 
         /// <summary>
@@ -112,6 +116,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// owned - User owns the book <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>
@@ -119,6 +124,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Number of stars given to the book (1-10) which will be mapped to 1-5 stars
         /// </summary>
         [JsonPropertyName("stars")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Stars { get; set; }
 
         /// <summary>
@@ -126,6 +132,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The book's review
         /// </summary>
         [JsonPropertyName("review")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Review { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/HiveBook.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/HiveBook.g.cs
@@ -83,6 +83,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The title of the book
         /// </summary>
         [JsonPropertyName("title")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Title { get; set; }
 
         /// <summary>
@@ -90,6 +91,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The authors of the book (tab separated)
         /// </summary>
         [JsonPropertyName("authors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Authors { get; set; }
 
         /// <summary>
@@ -97,6 +99,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The book's hive id, used to correlate user's books with the hive
         /// </summary>
         [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Id { get; set; }
 
         /// <summary>
@@ -104,6 +107,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The source service name (e.g. Goodreads)
         /// </summary>
         [JsonPropertyName("source")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Source { get; set; }
 
         /// <summary>
@@ -111,6 +115,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> URL to the book on the source service
         /// </summary>
         [JsonPropertyName("sourceUrl")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SourceUrl { get; set; }
 
         /// <summary>
@@ -118,6 +123,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> ID of the book in the source service
         /// </summary>
         [JsonPropertyName("sourceId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SourceId { get; set; }
 
         /// <summary>
@@ -125,6 +131,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> URL to full-size cover image
         /// </summary>
         [JsonPropertyName("cover")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cover { get; set; }
 
         /// <summary>
@@ -132,6 +139,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> URL to thumbnail image
         /// </summary>
         [JsonPropertyName("thumbnail")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Thumbnail { get; set; }
 
         /// <summary>
@@ -139,6 +147,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Book description/summary
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -146,6 +155,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Average rating (0-1000)
         /// </summary>
         [JsonPropertyName("rating")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Rating { get; set; }
 
         /// <summary>
@@ -153,18 +163,21 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Number of ratings
         /// </summary>
         [JsonPropertyName("ratingsCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? RatingsCount { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Gets or sets the updatedAt.
         /// </summary>
         [JsonPropertyName("updatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? UpdatedAt { get; set; }
 
         public const string RecordType = "buzz.bookhive.hiveBook";

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/Profile.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/Profile.g.cs
@@ -72,12 +72,14 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/Review.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/Review.g.cs
@@ -72,6 +72,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The number of stars given to the book
         /// </summary>
         [JsonPropertyName("stars")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Stars { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/SearchBooksOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/SearchBooksOutput.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The next offset to use for pagination (result of limit + offset)
         /// </summary>
         [JsonPropertyName("offset")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Offset { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/UserBook.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/UserBook.g.cs
@@ -118,6 +118,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The date the user started reading the book
         /// </summary>
         [JsonPropertyName("startedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? StartedAt { get; set; }
 
         /// <summary>
@@ -125,6 +126,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The date the user finished reading the book
         /// </summary>
         [JsonPropertyName("finishedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? FinishedAt { get; set; }
 
         /// <summary>
@@ -132,6 +134,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Cover image of the book
         /// </summary>
         [JsonPropertyName("cover")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cover { get; set; }
 
         /// <summary>
@@ -147,6 +150,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Book description/summary
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -154,6 +158,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Average rating (0-1000)
         /// </summary>
         [JsonPropertyName("rating")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Rating { get; set; }
 
         /// <summary>
@@ -166,6 +171,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// owned - User owns the book <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>
@@ -173,6 +179,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> Number of stars given to the book (1-10) which will be mapped to 1-5 stars
         /// </summary>
         [JsonPropertyName("stars")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Stars { get; set; }
 
         /// <summary>
@@ -180,6 +187,7 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
         /// <br/> The book's review
         /// </summary>
         [JsonPropertyName("review")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Review { get; set; }
 
         public const string RecordType = "buzz.bookhive.defs#userBook";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Actor/Declaration.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Actor/Declaration.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         /// following <br/>
         /// </summary>
         [JsonPropertyName("allowIncoming")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? AllowIncoming { get; set; }
 
         public const string RecordType = "chat.bsky.actor.declaration";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ProfileViewBasic.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ProfileViewBasic.g.cs
@@ -89,12 +89,14 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar.
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
@@ -102,6 +104,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated"/> (app.bsky.actor.defs#profileAssociated)
         /// </summary>
         [JsonPropertyName("associated")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileAssociated? Associated { get; set; }
 
         /// <summary>
@@ -109,12 +112,14 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ViewerState"/> (app.bsky.actor.defs#viewerState)
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ViewerState? Viewer { get; set; }
 
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -122,6 +127,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         /// <br/> Set to true when the actor cannot actively participate in conversations
         /// </summary>
         [JsonPropertyName("chatDisabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? ChatDisabled { get; set; }
 
         /// <summary>
@@ -129,6 +135,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.VerificationState"/> (app.bsky.actor.defs#verificationState)
         /// </summary>
         [JsonPropertyName("verification")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.VerificationState? Verification { get; set; }
 
         public const string RecordType = "chat.bsky.actor.defs#profileViewBasic";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/AcceptConvoOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/AcceptConvoOutput.g.cs
@@ -44,6 +44,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <br/> Rev when the convo was accepted. If not present, the convo was already accepted.
         /// </summary>
         [JsonPropertyName("rev")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Rev { get; set; }
 
         public const string RecordType = "chat.bsky.convo.acceptConvo#AcceptConvoOutput";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoView.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoView.g.cs
@@ -99,6 +99,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView"/> (chat.bsky.convo.defs#deletedMessageView) <br/>
         /// </summary>
         [JsonPropertyName("lastMessage")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? LastMessage { get; set; }
 
         /// <summary>
@@ -107,6 +108,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.MessageAndReactionView"/> (chat.bsky.convo.defs#messageAndReactionView) <br/>
         /// </summary>
         [JsonPropertyName("lastReaction")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Chat.Bsky.Convo.MessageAndReactionView? LastReaction { get; set; }
 
         /// <summary>
@@ -123,6 +125,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// accepted <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/GetConvoAvailabilityOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/GetConvoAvailabilityOutput.g.cs
@@ -56,6 +56,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <br/> <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.ConvoView"/> (chat.bsky.convo.defs#convoView)
         /// </summary>
         [JsonPropertyName("convo")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Chat.Bsky.Convo.ConvoView? Convo { get; set; }
 
         public const string RecordType = "chat.bsky.convo.getConvoAvailability#GetConvoAvailabilityOutput";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/GetLogOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/GetLogOutput.g.cs
@@ -58,6 +58,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/GetMessagesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/GetMessagesOutput.g.cs
@@ -50,6 +50,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ListConvosOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ListConvosOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/MessageInput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/MessageInput.g.cs
@@ -60,6 +60,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <br/> Annotations of text (mentions, URLs, hashtags, etc)
         /// </summary>
         [JsonPropertyName("facets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? Facets { get; set; }
 
         /// <summary>
@@ -68,6 +69,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Embed.EmbedRecord"/> (app.bsky.embed.record) <br/>
         /// </summary>
         [JsonPropertyName("embed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.EmbedRecord? Embed { get; set; }
 
         public const string RecordType = "chat.bsky.convo.defs#messageInput";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/MessageView.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/MessageView.g.cs
@@ -91,6 +91,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <br/> Annotations of text (mentions, URLs, hashtags, etc)
         /// </summary>
         [JsonPropertyName("facets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? Facets { get; set; }
 
         /// <summary>
@@ -99,6 +100,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <see cref="FishyFlip.Lexicon.App.Bsky.Embed.ViewRecordDef"/> (app.bsky.embed.record#view) <br/>
         /// </summary>
         [JsonPropertyName("embed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Embed.ViewRecordDef? Embed { get; set; }
 
         /// <summary>
@@ -106,6 +108,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// <br/> Reactions to this message, in ascending order of creation time.
         /// </summary>
         [JsonPropertyName("reactions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Chat.Bsky.Convo.ReactionView>? Reactions { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/UpdateAllReadInput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/UpdateAllReadInput.g.cs
@@ -50,6 +50,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// accepted <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "chat.bsky.convo.updateAllRead#UpdateAllReadInput";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/UpdateReadInput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/UpdateReadInput.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
         /// Gets or sets the messageId.
         /// </summary>
         [JsonPropertyName("messageId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? MessageId { get; set; }
 
         public const string RecordType = "chat.bsky.convo.updateRead#UpdateReadInput";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/UpdateActorAccessInput.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/UpdateActorAccessInput.g.cs
@@ -64,6 +64,7 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
         /// Gets or sets the ref.
         /// </summary>
         [JsonPropertyName("ref")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Ref { get; set; }
 
         public const string RecordType = "chat.bsky.moderation.updateActorAccess#UpdateActorAccessInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/AccountView.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/AccountView.g.cs
@@ -94,12 +94,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         /// <summary>
         /// Gets or sets the relatedRecords.
         /// </summary>
         [JsonPropertyName("relatedRecords")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<ATObject>? RelatedRecords { get; set; }
 
         /// <summary>
@@ -114,42 +116,49 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Server.InviteCode"/> (com.atproto.server.defs#inviteCode)
         /// </summary>
         [JsonPropertyName("invitedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Server.InviteCode? InvitedBy { get; set; }
 
         /// <summary>
         /// Gets or sets the invites.
         /// </summary>
         [JsonPropertyName("invites")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Server.InviteCode>? Invites { get; set; }
 
         /// <summary>
         /// Gets or sets the invitesDisabled.
         /// </summary>
         [JsonPropertyName("invitesDisabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? InvitesDisabled { get; set; }
 
         /// <summary>
         /// Gets or sets the emailConfirmedAt.
         /// </summary>
         [JsonPropertyName("emailConfirmedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? EmailConfirmedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the inviteNote.
         /// </summary>
         [JsonPropertyName("inviteNote")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? InviteNote { get; set; }
 
         /// <summary>
         /// Gets or sets the deactivatedAt.
         /// </summary>
         [JsonPropertyName("deactivatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? DeactivatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the threatSignatures.
         /// </summary>
         [JsonPropertyName("threatSignatures")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Admin.ThreatSignature>? ThreatSignatures { get; set; }
 
         public const string RecordType = "com.atproto.admin.defs#accountView";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/DisableAccountInvitesInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/DisableAccountInvitesInput.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> Optional reason for disabled invites.
         /// </summary>
         [JsonPropertyName("note")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Note { get; set; }
 
         public const string RecordType = "com.atproto.admin.disableAccountInvites#DisableAccountInvitesInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/DisableInviteCodesInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/DisableInviteCodesInput.g.cs
@@ -46,12 +46,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// Gets or sets the codes.
         /// </summary>
         [JsonPropertyName("codes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Codes { get; set; }
 
         /// <summary>
         /// Gets or sets the accounts.
         /// </summary>
         [JsonPropertyName("accounts")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Accounts { get; set; }
 
         public const string RecordType = "com.atproto.admin.disableInviteCodes#DisableInviteCodesInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/EnableAccountInvitesInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/EnableAccountInvitesInput.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> Optional reason for enabled invites.
         /// </summary>
         [JsonPropertyName("note")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Note { get; set; }
 
         public const string RecordType = "com.atproto.admin.enableAccountInvites#EnableAccountInvitesInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/GetInviteCodesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/GetInviteCodesOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/GetSubjectStatusOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/GetSubjectStatusOutput.g.cs
@@ -70,6 +70,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr"/> (com.atproto.admin.defs#statusAttr)
         /// </summary>
         [JsonPropertyName("takedown")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr? Takedown { get; set; }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr"/> (com.atproto.admin.defs#statusAttr)
         /// </summary>
         [JsonPropertyName("deactivated")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr? Deactivated { get; set; }
 
         public const string RecordType = "com.atproto.admin.getSubjectStatus#GetSubjectStatusOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/RepoBlobRef.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/RepoBlobRef.g.cs
@@ -64,6 +64,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// Gets or sets the recordUri.
         /// </summary>
         [JsonPropertyName("recordUri")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? RecordUri { get; set; }
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/SearchAccountsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/SearchAccountsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/SendEmailInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/SendEmailInput.g.cs
@@ -70,6 +70,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// Gets or sets the subject.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Subject { get; set; }
 
         /// <summary>
@@ -85,6 +86,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> Additional comment by the sender that won't be used in the email itself but helpful to provide more context for moderators/reviewers
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "com.atproto.admin.sendEmail#SendEmailInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/StatusAttr.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/StatusAttr.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// Gets or sets the ref.
         /// </summary>
         [JsonPropertyName("ref")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Ref { get; set; }
 
         public const string RecordType = "com.atproto.admin.defs#statusAttr";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/UpdateSubjectStatusInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/UpdateSubjectStatusInput.g.cs
@@ -70,6 +70,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr"/> (com.atproto.admin.defs#statusAttr)
         /// </summary>
         [JsonPropertyName("takedown")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr? Takedown { get; set; }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr"/> (com.atproto.admin.defs#statusAttr)
         /// </summary>
         [JsonPropertyName("deactivated")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr? Deactivated { get; set; }
 
         public const string RecordType = "com.atproto.admin.updateSubjectStatus#UpdateSubjectStatusInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/UpdateSubjectStatusOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/UpdateSubjectStatusOutput.g.cs
@@ -65,6 +65,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr"/> (com.atproto.admin.defs#statusAttr)
         /// </summary>
         [JsonPropertyName("takedown")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Admin.StatusAttr? Takedown { get; set; }
 
         public const string RecordType = "com.atproto.admin.updateSubjectStatus#UpdateSubjectStatusOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Identity/GetRecommendedDidCredentialsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Identity/GetRecommendedDidCredentialsOutput.g.cs
@@ -53,24 +53,28 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         /// <br/> Recommended rotation keys for PLC dids. Should be undefined (or ignored) for did:webs.
         /// </summary>
         [JsonPropertyName("rotationKeys")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? RotationKeys { get; set; }
 
         /// <summary>
         /// Gets or sets the alsoKnownAs.
         /// </summary>
         [JsonPropertyName("alsoKnownAs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? AlsoKnownAs { get; set; }
 
         /// <summary>
         /// Gets or sets the verificationMethods.
         /// </summary>
         [JsonPropertyName("verificationMethods")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? VerificationMethods { get; set; }
 
         /// <summary>
         /// Gets or sets the services.
         /// </summary>
         [JsonPropertyName("services")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Services { get; set; }
 
         public const string RecordType = "com.atproto.identity.getRecommendedDidCredentials#GetRecommendedDidCredentialsOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Identity/SignPlcOperationInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Identity/SignPlcOperationInput.g.cs
@@ -56,30 +56,35 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         /// <br/> A token received through com.atproto.identity.requestPlcOperationSignature
         /// </summary>
         [JsonPropertyName("token")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Token { get; set; }
 
         /// <summary>
         /// Gets or sets the rotationKeys.
         /// </summary>
         [JsonPropertyName("rotationKeys")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? RotationKeys { get; set; }
 
         /// <summary>
         /// Gets or sets the alsoKnownAs.
         /// </summary>
         [JsonPropertyName("alsoKnownAs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? AlsoKnownAs { get; set; }
 
         /// <summary>
         /// Gets or sets the verificationMethods.
         /// </summary>
         [JsonPropertyName("verificationMethods")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? VerificationMethods { get; set; }
 
         /// <summary>
         /// Gets or sets the services.
         /// </summary>
         [JsonPropertyName("services")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Services { get; set; }
 
         public const string RecordType = "com.atproto.identity.signPlcOperation#SignPlcOperationInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Label/Info.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Label/Info.g.cs
@@ -58,6 +58,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// Gets or sets the message.
         /// </summary>
         [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Message { get; set; }
 
         public const string RecordType = "com.atproto.label.subscribeLabels#info";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Label/Label.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Label/Label.g.cs
@@ -71,6 +71,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// <br/> The AT Protocol version of the label object.
         /// </summary>
         [JsonPropertyName("ver")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Ver { get; set; }
 
         /// <summary>
@@ -95,6 +96,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// <br/> Optionally, CID specifying the specific version of 'uri' resource this label applies to.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>
@@ -110,6 +112,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// <br/> If true, this is a negation label, overwriting a previous label.
         /// </summary>
         [JsonPropertyName("neg")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Neg { get; set; }
 
         /// <summary>
@@ -125,6 +128,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// <br/> Timestamp at which this label expires (no longer applies).
         /// </summary>
         [JsonPropertyName("exp")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? Exp { get; set; }
 
         /// <summary>
@@ -132,6 +136,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// <br/> Signature of dag-cbor encoded label.
         /// </summary>
         [JsonPropertyName("sig")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public byte[]? Sig { get; set; }
 
         public const string RecordType = "com.atproto.label.defs#label";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Label/LabelValueDefinition.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Label/LabelValueDefinition.g.cs
@@ -113,6 +113,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// hide <br/>
         /// </summary>
         [JsonPropertyName("defaultSetting")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DefaultSetting { get; set; } = "warn";
 
         /// <summary>
@@ -120,6 +121,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// <br/> Does the user need to have adult content enabled in order to configure this label?
         /// </summary>
         [JsonPropertyName("adultOnly")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AdultOnly { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Label/QueryLabelsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Label/QueryLabelsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Lexicon/Schema.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Lexicon/Schema.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Lexicon
         /// <br/> Indicates the 'version' of the Lexicon language. Must be '1' for the current atproto/Lexicon schema system.
         /// </summary>
         [JsonPropertyName("lexicon")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Lexicon { get; set; }
 
         public const string RecordType = "com.atproto.lexicon.schema";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Moderation/CreateReportInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Moderation/CreateReportInput.g.cs
@@ -79,6 +79,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Moderation
         /// <br/> Additional context about the content and violation.
         /// </summary>
         [JsonPropertyName("reason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Reason { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Moderation/CreateReportOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Moderation/CreateReportOutput.g.cs
@@ -93,6 +93,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Moderation
         /// Gets or sets the reason.
         /// </summary>
         [JsonPropertyName("reason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Reason { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/ApplyWritesInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/ApplyWritesInput.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons.
         /// </summary>
         [JsonPropertyName("validate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Validate { get; set; }
 
         /// <summary>
@@ -85,6 +86,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.
         /// </summary>
         [JsonPropertyName("swapCommit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SwapCommit { get; set; }
 
         public const string RecordType = "com.atproto.repo.applyWrites#ApplyWritesInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/ApplyWritesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/ApplyWritesOutput.g.cs
@@ -54,6 +54,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta"/> (com.atproto.repo.defs#commitMeta)
         /// </summary>
         [JsonPropertyName("commit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta? Commit { get; set; }
 
         /// <summary>
@@ -64,6 +65,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.DeleteResult"/> (com.atproto.repo.applyWrites#deleteResult) <br/>
         /// </summary>
         [JsonPropertyName("results")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<ATObject>? Results { get; set; }
 
         public const string RecordType = "com.atproto.repo.applyWrites#ApplyWritesOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/Create.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/Create.g.cs
@@ -60,6 +60,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility.
         /// </summary>
         [JsonPropertyName("rkey")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Rkey { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/CreateRecordInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/CreateRecordInput.g.cs
@@ -76,6 +76,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> The Record Key.
         /// </summary>
         [JsonPropertyName("rkey")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Rkey { get; set; }
 
         /// <summary>
@@ -83,6 +84,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.
         /// </summary>
         [JsonPropertyName("validate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Validate { get; set; }
 
         /// <summary>
@@ -98,6 +100,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Compare and swap with the previous commit by CID.
         /// </summary>
         [JsonPropertyName("swapCommit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SwapCommit { get; set; }
 
         public const string RecordType = "com.atproto.repo.createRecord#CreateRecordInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/CreateRecordOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/CreateRecordOutput.g.cs
@@ -74,6 +74,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta"/> (com.atproto.repo.defs#commitMeta)
         /// </summary>
         [JsonPropertyName("commit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta? Commit { get; set; }
 
         /// <summary>
@@ -83,6 +84,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// unknown <br/>
         /// </summary>
         [JsonPropertyName("validationStatus")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ValidationStatus { get; set; }
 
         public const string RecordType = "com.atproto.repo.createRecord#CreateRecordOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/CreateResult.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/CreateResult.g.cs
@@ -71,6 +71,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// unknown <br/>
         /// </summary>
         [JsonPropertyName("validationStatus")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ValidationStatus { get; set; }
 
         public const string RecordType = "com.atproto.repo.applyWrites#createResult";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/DeleteRecordInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/DeleteRecordInput.g.cs
@@ -81,6 +81,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Compare and swap with the previous record by CID.
         /// </summary>
         [JsonPropertyName("swapRecord")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SwapRecord { get; set; }
 
         /// <summary>
@@ -88,6 +89,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Compare and swap with the previous commit by CID.
         /// </summary>
         [JsonPropertyName("swapCommit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SwapCommit { get; set; }
 
         public const string RecordType = "com.atproto.repo.deleteRecord#DeleteRecordInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/DeleteRecordOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/DeleteRecordOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta"/> (com.atproto.repo.defs#commitMeta)
         /// </summary>
         [JsonPropertyName("commit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta? Commit { get; set; }
 
         public const string RecordType = "com.atproto.repo.deleteRecord#DeleteRecordOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/GetRecordOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/GetRecordOutput.g.cs
@@ -57,6 +57,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/ListMissingBlobsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/ListMissingBlobsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/ListRecordsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/ListRecordsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/PutRecordInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/PutRecordInput.g.cs
@@ -87,6 +87,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.
         /// </summary>
         [JsonPropertyName("validate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Validate { get; set; }
 
         /// <summary>
@@ -102,6 +103,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Compare and swap with the previous record by CID. WARNING: nullable and optional field; may cause problems with golang implementation
         /// </summary>
         [JsonPropertyName("swapRecord")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SwapRecord { get; set; }
 
         /// <summary>
@@ -109,6 +111,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> Compare and swap with the previous commit by CID.
         /// </summary>
         [JsonPropertyName("swapCommit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SwapCommit { get; set; }
 
         public const string RecordType = "com.atproto.repo.putRecord#PutRecordInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/PutRecordOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/PutRecordOutput.g.cs
@@ -74,6 +74,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta"/> (com.atproto.repo.defs#commitMeta)
         /// </summary>
         [JsonPropertyName("commit")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Repo.CommitMeta? Commit { get; set; }
 
         /// <summary>
@@ -83,6 +84,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// unknown <br/>
         /// </summary>
         [JsonPropertyName("validationStatus")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ValidationStatus { get; set; }
 
         public const string RecordType = "com.atproto.repo.putRecord#PutRecordOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/UpdateResult.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/UpdateResult.g.cs
@@ -71,6 +71,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
         /// unknown <br/>
         /// </summary>
         [JsonPropertyName("validationStatus")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ValidationStatus { get; set; }
 
         public const string RecordType = "com.atproto.repo.applyWrites#updateResult";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/AppPassword.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/AppPassword.g.cs
@@ -73,6 +73,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the privileged.
         /// </summary>
         [JsonPropertyName("privileged")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Privileged { get; set; }
 
         public const string RecordType = "com.atproto.server.createAppPassword#appPassword";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/AppPasswordDef.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/AppPasswordDef.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the privileged.
         /// </summary>
         [JsonPropertyName("privileged")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Privileged { get; set; }
 
         public const string RecordType = "com.atproto.server.listAppPasswords#appPassword";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/Contact.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/Contact.g.cs
@@ -43,6 +43,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         public const string RecordType = "com.atproto.server.describeServer#contact";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateAccountInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateAccountInput.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         /// <summary>
@@ -83,6 +84,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> Pre-existing atproto DID, being imported to a new account.
         /// </summary>
         [JsonPropertyName("did")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Did { get; set; }
 
@@ -90,18 +92,21 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the inviteCode.
         /// </summary>
         [JsonPropertyName("inviteCode")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? InviteCode { get; set; }
 
         /// <summary>
         /// Gets or sets the verificationCode.
         /// </summary>
         [JsonPropertyName("verificationCode")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? VerificationCode { get; set; }
 
         /// <summary>
         /// Gets or sets the verificationPhone.
         /// </summary>
         [JsonPropertyName("verificationPhone")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? VerificationPhone { get; set; }
 
         /// <summary>
@@ -109,6 +114,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> Initial account password. May need to meet instance-specific password strength requirements.
         /// </summary>
         [JsonPropertyName("password")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Password { get; set; }
 
         /// <summary>
@@ -116,6 +122,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> DID PLC rotation key (aka, recovery key) to be included in PLC creation operation.
         /// </summary>
         [JsonPropertyName("recoveryKey")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RecoveryKey { get; set; }
 
         /// <summary>
@@ -123,6 +130,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> A signed DID PLC operation to be submitted as part of importing an existing account to this instance. NOTE: this optional field may be updated when full account migration is implemented.
         /// </summary>
         [JsonPropertyName("plcOp")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? PlcOp { get; set; }
 
         public const string RecordType = "com.atproto.server.createAccount#CreateAccountInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateAccountOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateAccountOutput.g.cs
@@ -90,6 +90,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> Complete DID document.
         /// </summary>
         [JsonPropertyName("didDoc")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Models.DidDoc? DidDoc { get; set; }
 
         public const string RecordType = "com.atproto.server.createAccount#CreateAccountOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateAppPasswordInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateAppPasswordInput.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients.
         /// </summary>
         [JsonPropertyName("privileged")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Privileged { get; set; }
 
         public const string RecordType = "com.atproto.server.createAppPassword#CreateAppPasswordInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateInviteCodeInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateInviteCodeInput.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the forAccount.
         /// </summary>
         [JsonPropertyName("forAccount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? ForAccount { get; set; }
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateInviteCodesInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateInviteCodesInput.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the forAccounts.
         /// </summary>
         [JsonPropertyName("forAccounts")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Models.ATDid>? ForAccounts { get; set; }
 
         public const string RecordType = "com.atproto.server.createInviteCodes#CreateInviteCodesInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateSessionInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateSessionInput.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the authFactorToken.
         /// </summary>
         [JsonPropertyName("authFactorToken")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? AuthFactorToken { get; set; }
 
         /// <summary>
@@ -74,6 +75,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> When true, instead of throwing error for takendown accounts, a valid response with a narrow scoped token will be returned
         /// </summary>
         [JsonPropertyName("allowTakendown")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AllowTakendown { get; set; }
 
         public const string RecordType = "com.atproto.server.createSession#CreateSessionInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateSessionOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/CreateSessionOutput.g.cs
@@ -105,30 +105,35 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the didDoc.
         /// </summary>
         [JsonPropertyName("didDoc")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Models.DidDoc? DidDoc { get; set; }
 
         /// <summary>
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         /// <summary>
         /// Gets or sets the emailConfirmed.
         /// </summary>
         [JsonPropertyName("emailConfirmed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? EmailConfirmed { get; set; }
 
         /// <summary>
         /// Gets or sets the emailAuthFactor.
         /// </summary>
         [JsonPropertyName("emailAuthFactor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? EmailAuthFactor { get; set; }
 
         /// <summary>
         /// Gets or sets the active.
         /// </summary>
         [JsonPropertyName("active")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Active { get; set; }
 
         /// <summary>
@@ -140,6 +145,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// deactivated <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "com.atproto.server.createSession#CreateSessionOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/DeactivateAccountInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/DeactivateAccountInput.g.cs
@@ -44,6 +44,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> A recommendation to server as to how long they should hold onto the deactivated account before deleting.
         /// </summary>
         [JsonPropertyName("deleteAfter")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? DeleteAfter { get; set; }
 
         public const string RecordType = "com.atproto.server.deactivateAccount#DeactivateAccountInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/DescribeServerOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/DescribeServerOutput.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> If true, an invite code must be supplied to create an account on this instance.
         /// </summary>
         [JsonPropertyName("inviteCodeRequired")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? InviteCodeRequired { get; set; }
 
         /// <summary>
@@ -70,6 +71,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> If true, a phone verification token must be supplied to create an account on this instance.
         /// </summary>
         [JsonPropertyName("phoneVerificationRequired")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? PhoneVerificationRequired { get; set; }
 
         /// <summary>
@@ -86,6 +88,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// com.atproto.server.defs#links <br/>
         /// </summary>
         [JsonPropertyName("links")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Server.Links? Links { get; set; }
 
         /// <summary>
@@ -94,6 +97,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// com.atproto.server.defs#contact <br/>
         /// </summary>
         [JsonPropertyName("contact")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Server.Contact? Contact { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/GetSessionOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/GetSessionOutput.g.cs
@@ -85,30 +85,35 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         /// <summary>
         /// Gets or sets the emailConfirmed.
         /// </summary>
         [JsonPropertyName("emailConfirmed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? EmailConfirmed { get; set; }
 
         /// <summary>
         /// Gets or sets the emailAuthFactor.
         /// </summary>
         [JsonPropertyName("emailAuthFactor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? EmailAuthFactor { get; set; }
 
         /// <summary>
         /// Gets or sets the didDoc.
         /// </summary>
         [JsonPropertyName("didDoc")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Models.DidDoc? DidDoc { get; set; }
 
         /// <summary>
         /// Gets or sets the active.
         /// </summary>
         [JsonPropertyName("active")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Active { get; set; }
 
         /// <summary>
@@ -120,6 +125,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// deactivated <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "com.atproto.server.getSession#GetSessionOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/Links.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/Links.g.cs
@@ -46,12 +46,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the privacyPolicy.
         /// </summary>
         [JsonPropertyName("privacyPolicy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? PrivacyPolicy { get; set; }
 
         /// <summary>
         /// Gets or sets the termsOfService.
         /// </summary>
         [JsonPropertyName("termsOfService")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? TermsOfService { get; set; }
 
         public const string RecordType = "com.atproto.server.describeServer#links";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/RefreshSessionOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/RefreshSessionOutput.g.cs
@@ -96,12 +96,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the didDoc.
         /// </summary>
         [JsonPropertyName("didDoc")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Models.DidDoc? DidDoc { get; set; }
 
         /// <summary>
         /// Gets or sets the active.
         /// </summary>
         [JsonPropertyName("active")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Active { get; set; }
 
         /// <summary>
@@ -113,6 +115,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// deactivated <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "com.atproto.server.refreshSession#RefreshSessionOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/ReserveSigningKeyInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/ReserveSigningKeyInput.g.cs
@@ -44,6 +44,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> The DID to reserve a key for.
         /// </summary>
         [JsonPropertyName("did")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? Did { get; set; }
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/UpdateEmailInput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/UpdateEmailInput.g.cs
@@ -56,6 +56,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// Gets or sets the emailAuthFactor.
         /// </summary>
         [JsonPropertyName("emailAuthFactor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? EmailAuthFactor { get; set; }
 
         /// <summary>
@@ -63,6 +64,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         /// <br/> Requires a token from com.atproto.sever.requestEmailUpdate if the account's email has been confirmed.
         /// </summary>
         [JsonPropertyName("token")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Token { get; set; }
 
         public const string RecordType = "com.atproto.server.updateEmail#UpdateEmailInput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/Account.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/Account.g.cs
@@ -104,6 +104,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// throttled <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "com.atproto.sync.subscribeRepos#account";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/Commit.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/Commit.g.cs
@@ -138,6 +138,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <br/> The root CID of the MST tree for the previous commit from this repo (indicated by the 'since' revision field in this message). Corresponds to the 'data' field in the repo commit object. NOTE: this field is effectively required for the 'inductive' version of firehose.
         /// </summary>
         [JsonPropertyName("prevData")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATCidJsonConverter))]
         public Ipfs.Cid? PrevData { get; set; }
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/GetHostStatusOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/GetHostStatusOutput.g.cs
@@ -67,6 +67,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <br/> Recent repo stream event sequence number. May be delayed from actual stream processing (eg, persisted cursor not in-memory cursor).
         /// </summary>
         [JsonPropertyName("seq")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Seq { get; set; }
 
         /// <summary>
@@ -74,6 +75,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <br/> Number of accounts on the server which are associated with the upstream host. Note that the upstream may actually have more accounts.
         /// </summary>
         [JsonPropertyName("accountCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? AccountCount { get; set; }
 
         /// <summary>
@@ -86,6 +88,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// banned <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "com.atproto.sync.getHostStatus#GetHostStatusOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/GetRepoStatusOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/GetRepoStatusOutput.g.cs
@@ -83,6 +83,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// throttled <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>
@@ -90,6 +91,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <br/> Optional field, the current rev of the repo, if active=true
         /// </summary>
         [JsonPropertyName("rev")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Rev { get; set; }
 
         public const string RecordType = "com.atproto.sync.getRepoStatus#GetRepoStatusOutput";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/Host.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/Host.g.cs
@@ -68,12 +68,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <br/> Recent repo stream event sequence number. May be delayed from actual stream processing (eg, persisted cursor not in-memory cursor).
         /// </summary>
         [JsonPropertyName("seq")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Seq { get; set; }
 
         /// <summary>
         /// Gets or sets the accountCount.
         /// </summary>
         [JsonPropertyName("accountCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? AccountCount { get; set; }
 
         /// <summary>
@@ -86,6 +88,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// banned <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "com.atproto.sync.listHosts#host";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/Identity.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/Identity.g.cs
@@ -78,6 +78,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <br/> The current handle for the account, or 'handle.invalid' if validation fails. This field is optional, might have been validated or passed-through from an upstream source. Semantics and behaviors for PDS vs Relay may evolve in the future; see atproto specs for more details.
         /// </summary>
         [JsonPropertyName("handle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATHandleJsonConverter))]
         public FishyFlip.Models.ATHandle? Handle { get; set; }
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/Info.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/Info.g.cs
@@ -58,6 +58,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// Gets or sets the message.
         /// </summary>
         [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Message { get; set; }
 
         public const string RecordType = "com.atproto.sync.subscribeRepos#info";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListBlobsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListBlobsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListHostsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListHostsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListReposByCollectionOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListReposByCollectionOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListReposOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/ListReposOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/Repo.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/Repo.g.cs
@@ -86,6 +86,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// Gets or sets the active.
         /// </summary>
         [JsonPropertyName("active")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Active { get; set; }
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// throttled <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         public const string RecordType = "com.atproto.sync.listRepos#repo";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/RepoOp.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/RepoOp.g.cs
@@ -88,6 +88,7 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
         /// <br/> For updates and deletes, the previous record CID (required for inductive firehose). For creations, field should not be defined.
         /// </summary>
         [JsonPropertyName("prev")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATCidJsonConverter))]
         public Ipfs.Cid? Prev { get; set; }
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Temp/CheckSignupQueueOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Temp/CheckSignupQueueOutput.g.cs
@@ -56,12 +56,14 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
         /// Gets or sets the placeInQueue.
         /// </summary>
         [JsonPropertyName("placeInQueue")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? PlaceInQueue { get; set; }
 
         /// <summary>
         /// Gets or sets the estimatedTimeMs.
         /// </summary>
         [JsonPropertyName("estimatedTimeMs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? EstimatedTimeMs { get; set; }
 
         public const string RecordType = "com.atproto.temp.checkSignupQueue#CheckSignupQueueOutput";

--- a/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/HydratedOekaki.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/HydratedOekaki.g.cs
@@ -118,6 +118,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// <br/> An array of tags this image had.
         /// </summary>
         [JsonPropertyName("tags")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Tags { get; set; }
 
         /// <summary>
@@ -125,6 +126,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// <br/> Alt text description of the image, for accessibility.
         /// </summary>
         [JsonPropertyName("alt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Alt { get; set; }
 
         public const string RecordType = "com.shinolabs.pinksea.appViewDefs#hydratedOekaki";

--- a/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/ImageLink.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/ImageLink.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// <br/> Alt text description of the image, for accessibility.
         /// </summary>
         [JsonPropertyName("alt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Alt { get; set; }
 
         public const string RecordType = "com.shinolabs.pinksea.oekaki#imageLink";

--- a/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/Oekaki.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/Oekaki.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// <br/> The timestamp of creation.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -70,6 +71,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// com.shinolabs.pinksea.defs#image <br/>
         /// </summary>
         [JsonPropertyName("image")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Shinolabs.Pinksea.Image? Image { get; set; }
 
         /// <summary>
@@ -77,6 +79,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// <br/> An array of tags this image had.
         /// </summary>
         [JsonPropertyName("tags")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Tags { get; set; }
 
         /// <summary>
@@ -85,6 +88,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("inResponseTo")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? InResponseTo { get; set; }
 
         /// <summary>
@@ -92,6 +96,7 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         /// <br/> Is this oekaki NSFW?
         /// </summary>
         [JsonPropertyName("nsfw")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Nsfw { get; set; }
 
         public const string RecordType = "com.shinolabs.pinksea.oekaki";

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlobMetadata.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlobMetadata.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         /// Gets or sets the name.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         public const string RecordType = "com.whtwnd.blog.defs#blobMetadata";

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEntry.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEntry.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "com.whtwnd.blog.defs#blogEntry";

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/Entry.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/Entry.g.cs
@@ -69,24 +69,28 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         /// Gets or sets the content.
         /// </summary>
         [JsonPropertyName("content")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Content { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Gets or sets the title.
         /// </summary>
         [JsonPropertyName("title")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Title { get; set; }
 
         /// <summary>
         /// Gets or sets the subtitle.
         /// </summary>
         [JsonPropertyName("subtitle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Subtitle { get; set; }
 
         /// <summary>
@@ -94,18 +98,21 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Whtwnd.Blog.Ogp"/> (com.whtwnd.blog.defs#ogp)
         /// </summary>
         [JsonPropertyName("ogp")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Whtwnd.Blog.Ogp? Ogp { get; set; }
 
         /// <summary>
         /// Gets or sets the theme.
         /// </summary>
         [JsonPropertyName("theme")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Theme { get; set; }
 
         /// <summary>
         /// Gets or sets the blobs.
         /// </summary>
         [JsonPropertyName("blobs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Whtwnd.Blog.BlobMetadata>? Blobs { get; set; }
 
         /// <summary>
@@ -113,6 +120,7 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         /// <br/> Tells the visibility of the article to AppView.
         /// </summary>
         [JsonPropertyName("visibility")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Visibility { get; set; } = "public";
 
         public const string RecordType = "com.whtwnd.blog.entry";

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/GetEntryMetadataByNameOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/GetEntryMetadataByNameOutput.g.cs
@@ -57,12 +57,14 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         /// Gets or sets the lastUpdate.
         /// </summary>
         [JsonPropertyName("lastUpdate")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? LastUpdate { get; set; }
 
         /// <summary>
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         public const string RecordType = "com.whtwnd.blog.getEntryMetadataByName#GetEntryMetadataByNameOutput";

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/Ogp.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/Ogp.g.cs
@@ -56,12 +56,14 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
         /// Gets or sets the width.
         /// </summary>
         [JsonPropertyName("width")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Width { get; set; }
 
         /// <summary>
         /// Gets or sets the height.
         /// </summary>
         [JsonPropertyName("height")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Height { get; set; }
 
         public const string RecordType = "com.whtwnd.blog.defs#ogp";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Bookmarks/Bookmark.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Bookmarks/Bookmark.g.cs
@@ -52,12 +52,14 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Bookmarks
         /// Gets or sets the subject.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Subject { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -65,6 +67,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Bookmarks
         /// <br/> Tags for content the bookmark may be related to, for example 'news' or 'funny videos'
         /// </summary>
         [JsonPropertyName("tags")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Tags { get; set; }
 
         public const string RecordType = "community.lexicon.bookmarks.bookmark";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Bookmarks/GetActorBookmarksOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Bookmarks/GetActorBookmarksOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Bookmarks
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Calendar/Event.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Calendar/Event.g.cs
@@ -90,6 +90,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> The name of the event.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
@@ -97,6 +98,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> The description of the event.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -104,6 +106,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> Client-declared timestamp when the event was created.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -111,6 +114,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> Client-declared timestamp when the event starts.
         /// </summary>
         [JsonPropertyName("startsAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? StartsAt { get; set; }
 
         /// <summary>
@@ -118,6 +122,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> Client-declared timestamp when the event ends.
         /// </summary>
         [JsonPropertyName("endsAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? EndsAt { get; set; }
 
         /// <summary>
@@ -129,6 +134,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// community.lexicon.calendar.event#virtual - A virtual event that takes place online. <br/>
         /// </summary>
         [JsonPropertyName("mode")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Mode { get; set; }
 
         /// <summary>
@@ -142,6 +148,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// community.lexicon.calendar.event#scheduled - The event has been created and scheduled. <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>
@@ -155,6 +162,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <see cref="FishyFlip.Lexicon.Community.Lexicon.Location.Hthree"/> (community.lexicon.location.hthree) <br/>
         /// </summary>
         [JsonPropertyName("locations")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<ATObject>? Locations { get; set; }
 
         /// <summary>
@@ -162,6 +170,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> URIs associated with the event.
         /// </summary>
         [JsonPropertyName("uris")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Community.Lexicon.Calendar.Uri>? Uris { get; set; }
 
         public const string RecordType = "community.lexicon.calendar.event";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Calendar/Rsvp.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Calendar/Rsvp.g.cs
@@ -57,6 +57,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Subject { get; set; }
 
         /// <summary>
@@ -67,6 +68,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// notgoing - Not going to the event <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; } = "community.lexicon.calendar.rsvp#going";
 
         public const string RecordType = "community.lexicon.calendar.rsvp";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Calendar/Uri.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Calendar/Uri.g.cs
@@ -57,6 +57,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Calendar
         /// <br/> The display name of the URI.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         public const string RecordType = "community.lexicon.calendar.event#uri";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Interaction/Like.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Interaction/Like.g.cs
@@ -52,12 +52,14 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Interaction
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Subject { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "community.lexicon.interaction.like";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Location/Address.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Location/Address.g.cs
@@ -70,6 +70,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The postal code of the location.
         /// </summary>
         [JsonPropertyName("postalCode")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? PostalCode { get; set; }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The administrative region of the country. For example, a state in the USA.
         /// </summary>
         [JsonPropertyName("region")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Region { get; set; }
 
         /// <summary>
@@ -84,6 +86,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The locality of the region. For example, a city in the USA.
         /// </summary>
         [JsonPropertyName("locality")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Locality { get; set; }
 
         /// <summary>
@@ -91,6 +94,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The street address.
         /// </summary>
         [JsonPropertyName("street")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Street { get; set; }
 
         /// <summary>
@@ -98,6 +102,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The name of the location.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         public const string RecordType = "community.lexicon.location.address";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Location/Fsq.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Location/Fsq.g.cs
@@ -63,12 +63,14 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// Gets or sets the latitude.
         /// </summary>
         [JsonPropertyName("latitude")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Latitude { get; set; }
 
         /// <summary>
         /// Gets or sets the longitude.
         /// </summary>
         [JsonPropertyName("longitude")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Longitude { get; set; }
 
         /// <summary>
@@ -76,6 +78,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The name of the location.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         public const string RecordType = "community.lexicon.location.fsq";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Location/Geo.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Location/Geo.g.cs
@@ -69,6 +69,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// Gets or sets the altitude.
         /// </summary>
         [JsonPropertyName("altitude")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Altitude { get; set; }
 
         /// <summary>
@@ -76,6 +77,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The name of the location.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         public const string RecordType = "community.lexicon.location.geo";

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Location/Hthree.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Location/Hthree.g.cs
@@ -58,6 +58,7 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Location
         /// <br/> The name of the location.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         public const string RecordType = "community.lexicon.location.hthree";

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/MiniProfileView.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/MiniProfileView.g.cs
@@ -53,18 +53,21 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> The decentralized identifier of the actor
         /// </summary>
         [JsonPropertyName("did")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Did { get; set; }
 
         /// <summary>
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the handle.
         /// </summary>
         [JsonPropertyName("handle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Handle { get; set; }
 
         /// <summary>
@@ -72,6 +75,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> IPLD of the avatar
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         public const string RecordType = "fm.teal.alpha.actor.defs#miniProfileView";

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/Profile.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/Profile.g.cs
@@ -66,6 +66,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
@@ -73,6 +74,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> Free-form profile description text.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -80,6 +82,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> Annotations of text in the profile description (mentions, URLs, hashtags, etc).
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
@@ -88,6 +91,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// fm.teal.alpha.actor.defs#featuredItem <br/>
         /// </summary>
         [JsonPropertyName("featuredItem")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.FeaturedItem? FeaturedItem { get; set; }
 
         /// <summary>
@@ -95,6 +99,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> Small image to be displayed next to posts from account. AKA, 'profile picture'
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Avatar { get; set; }
 
         /// <summary>
@@ -102,12 +107,14 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> Larger horizontal image to display behind profile view.
         /// </summary>
         [JsonPropertyName("banner")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Blob? Banner { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "fm.teal.alpha.actor.profile";

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/ProfileView.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/ProfileView.g.cs
@@ -67,12 +67,14 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> The decentralized identifier of the actor
         /// </summary>
         [JsonPropertyName("did")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Did { get; set; }
 
         /// <summary>
         /// Gets or sets the displayName.
         /// </summary>
         [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DisplayName { get; set; }
 
         /// <summary>
@@ -80,6 +82,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> Free-form profile description text.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -87,6 +90,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> Annotations of text in the profile description (mentions, URLs, hashtags, etc). May be changed to another (backwards compatible) lexicon.
         /// </summary>
         [JsonPropertyName("descriptionFacets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.App.Bsky.Richtext.Facet>? DescriptionFacets { get; set; }
 
         /// <summary>
@@ -95,6 +99,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.FeaturedItem"/> (fm.teal.alpha.actor.profile#featuredItem)
         /// </summary>
         [JsonPropertyName("featuredItem")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.FeaturedItem? FeaturedItem { get; set; }
 
         /// <summary>
@@ -102,6 +107,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> IPLD of the avatar
         /// </summary>
         [JsonPropertyName("avatar")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Avatar { get; set; }
 
         /// <summary>
@@ -109,12 +115,14 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> IPLD of the banner image
         /// </summary>
         [JsonPropertyName("banner")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Banner { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "fm.teal.alpha.actor.defs#profileView";

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/SearchActorsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/SearchActorsOutput.g.cs
@@ -54,6 +54,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> Cursor for pagination
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         public const string RecordType = "fm.teal.alpha.actor.searchActors#SearchActorsOutput";

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/Status.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/Status.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> The unix timestamp of when the item was recorded
         /// </summary>
         [JsonPropertyName("time")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? Time { get; set; }
 
         /// <summary>
@@ -62,6 +63,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> The unix timestamp of the expiry time of the item. If unavailable, default to 10 minutes past the start time.
         /// </summary>
         [JsonPropertyName("expiry")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? Expiry { get; set; }
 
         /// <summary>
@@ -69,6 +71,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
         /// <br/> <see cref="FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.PlayView"/> (fm.teal.alpha.feed.defs#playView)
         /// </summary>
         [JsonPropertyName("item")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.PlayView? Item { get; set; }
 
         public const string RecordType = "fm.teal.alpha.actor.status";

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Feed/Play.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Feed/Play.g.cs
@@ -80,6 +80,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The name of the track
         /// </summary>
         [JsonPropertyName("trackName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? TrackName { get; set; }
 
         /// <summary>
@@ -87,6 +88,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The Musicbrainz ID of the track
         /// </summary>
         [JsonPropertyName("trackMbId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? TrackMbId { get; set; }
 
         /// <summary>
@@ -94,6 +96,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The Musicbrainz recording ID of the track
         /// </summary>
         [JsonPropertyName("recordingMbId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RecordingMbId { get; set; }
 
         /// <summary>
@@ -101,6 +104,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The length of the track in seconds
         /// </summary>
         [JsonPropertyName("duration")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Duration { get; set; }
 
         /// <summary>
@@ -108,6 +112,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> Array of artist names in order of original appearance.
         /// </summary>
         [JsonPropertyName("artistNames")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? ArtistNames { get; set; }
 
         /// <summary>
@@ -115,6 +120,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> Array of Musicbrainz artist IDs
         /// </summary>
         [JsonPropertyName("artistMbIds")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? ArtistMbIds { get; set; }
 
         /// <summary>
@@ -122,6 +128,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The name of the release/album
         /// </summary>
         [JsonPropertyName("releaseName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ReleaseName { get; set; }
 
         /// <summary>
@@ -129,6 +136,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The Musicbrainz release ID
         /// </summary>
         [JsonPropertyName("releaseMbId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ReleaseMbId { get; set; }
 
         /// <summary>
@@ -136,6 +144,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The ISRC code associated with the recording
         /// </summary>
         [JsonPropertyName("isrc")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Isrc { get; set; }
 
         /// <summary>
@@ -143,6 +152,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The URL associated with this track
         /// </summary>
         [JsonPropertyName("originUrl")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? OriginUrl { get; set; }
 
         /// <summary>
@@ -150,6 +160,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if unavailable or not provided.
         /// </summary>
         [JsonPropertyName("musicServiceBaseDomain")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? MusicServiceBaseDomain { get; set; }
 
         /// <summary>
@@ -157,6 +168,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> A metadata string specifying the user agent where the format is `<app-identifier>/<version> (<kernel/OS-base>; <platform/OS-version>; <device-model>)`. If string is provided, only `app-identifier` and `version` are required. `app-identifier` is recommended to be in reverse dns format. Defaults to 'manual/unknown' if unavailable or not provided.
         /// </summary>
         [JsonPropertyName("submissionClientAgent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SubmissionClientAgent { get; set; }
 
         /// <summary>
@@ -164,6 +176,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The unix timestamp of when the track was played
         /// </summary>
         [JsonPropertyName("playedTime")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? PlayedTime { get; set; }
 
         public const string RecordType = "fm.teal.alpha.feed.play";

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Feed/PlayView.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Feed/PlayView.g.cs
@@ -88,6 +88,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The Musicbrainz ID of the track
         /// </summary>
         [JsonPropertyName("trackMbId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? TrackMbId { get; set; }
 
         /// <summary>
@@ -95,6 +96,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The Musicbrainz recording ID of the track
         /// </summary>
         [JsonPropertyName("recordingMbId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RecordingMbId { get; set; }
 
         /// <summary>
@@ -102,6 +104,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The length of the track in seconds
         /// </summary>
         [JsonPropertyName("duration")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? Duration { get; set; }
 
         /// <summary>
@@ -117,6 +120,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> Array of Musicbrainz artist IDs
         /// </summary>
         [JsonPropertyName("artistMbIds")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? ArtistMbIds { get; set; }
 
         /// <summary>
@@ -124,6 +128,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The name of the release/album
         /// </summary>
         [JsonPropertyName("releaseName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ReleaseName { get; set; }
 
         /// <summary>
@@ -131,6 +136,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The Musicbrainz release ID
         /// </summary>
         [JsonPropertyName("releaseMbId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ReleaseMbId { get; set; }
 
         /// <summary>
@@ -138,6 +144,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The ISRC code associated with the recording
         /// </summary>
         [JsonPropertyName("isrc")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Isrc { get; set; }
 
         /// <summary>
@@ -145,6 +152,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The URL associated with this track
         /// </summary>
         [JsonPropertyName("originUrl")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? OriginUrl { get; set; }
 
         /// <summary>
@@ -152,6 +160,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if not provided.
         /// </summary>
         [JsonPropertyName("musicServiceBaseDomain")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? MusicServiceBaseDomain { get; set; }
 
         /// <summary>
@@ -159,6 +168,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> A user-agent style string specifying the user agent. e.g. tealtracker/0.0.1b (Linux; Android 13; SM-A715F). Defaults to 'manual/unknown' if not provided.
         /// </summary>
         [JsonPropertyName("submissionClientAgent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SubmissionClientAgent { get; set; }
 
         /// <summary>
@@ -166,6 +176,7 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
         /// <br/> The unix timestamp of when the track was played
         /// </summary>
         [JsonPropertyName("playedTime")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? PlayedTime { get; set; }
 
         public const string RecordType = "fm.teal.alpha.feed.defs#playView";

--- a/src/FishyFlip/Lexicon/Fyi/Unravel/Frontpage/Comment.g.cs
+++ b/src/FishyFlip/Lexicon/Fyi/Unravel/Frontpage/Comment.g.cs
@@ -60,6 +60,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> The content of the comment.
         /// </summary>
         [JsonPropertyName("content")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Content { get; set; }
 
         /// <summary>
@@ -67,6 +68,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> Client-declared timestamp when this comment was originally created.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
@@ -74,6 +76,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("parent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Parent { get; set; }
 
         /// <summary>
@@ -81,6 +84,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("post")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Post { get; set; }
 
         public const string RecordType = "fyi.unravel.frontpage.comment";

--- a/src/FishyFlip/Lexicon/Fyi/Unravel/Frontpage/Post.g.cs
+++ b/src/FishyFlip/Lexicon/Fyi/Unravel/Frontpage/Post.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> The title of the post.
         /// </summary>
         [JsonPropertyName("title")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Title { get; set; }
 
         /// <summary>
@@ -60,6 +61,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> The URL of the post.
         /// </summary>
         [JsonPropertyName("url")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Url { get; set; }
 
         /// <summary>
@@ -67,6 +69,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> Client-declared timestamp when this post was originally created.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "fyi.unravel.frontpage.post";

--- a/src/FishyFlip/Lexicon/Fyi/Unravel/Frontpage/Vote.g.cs
+++ b/src/FishyFlip/Lexicon/Fyi/Unravel/Frontpage/Vote.g.cs
@@ -52,6 +52,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Subject { get; set; }
 
         /// <summary>
@@ -59,6 +60,7 @@ namespace FishyFlip.Lexicon.Fyi.Unravel.Frontpage
         /// <br/> Client-declared timestamp when this vote was originally created.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "fyi.unravel.frontpage.vote";

--- a/src/FishyFlip/Lexicon/Link/Pastesphere/Snippet.g.cs
+++ b/src/FishyFlip/Lexicon/Link/Pastesphere/Snippet.g.cs
@@ -58,30 +58,35 @@ namespace FishyFlip.Lexicon.Link.Pastesphere
         /// Gets or sets the title.
         /// </summary>
         [JsonPropertyName("title")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Title { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the type.
         /// </summary>
         [JsonPropertyName("type")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? TypeValue { get; set; }
 
         /// <summary>
         /// Gets or sets the body.
         /// </summary>
         [JsonPropertyName("body")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Body { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "link.pastesphere.snippet";

--- a/src/FishyFlip/Lexicon/Ma/Tokono/Byov/Subscription.g.cs
+++ b/src/FishyFlip/Lexicon/Ma/Tokono/Byov/Subscription.g.cs
@@ -49,12 +49,14 @@ namespace FishyFlip.Lexicon.Ma.Tokono.Byov
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = default;
 
         /// <summary>
         /// Gets or sets the subject.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Subject { get; set; }
 
         public const string RecordType = "ma.tokono.byov.subscription";

--- a/src/FishyFlip/Lexicon/Ma/Tokono/Byov/Video.g.cs
+++ b/src/FishyFlip/Lexicon/Ma/Tokono/Byov/Video.g.cs
@@ -58,30 +58,35 @@ namespace FishyFlip.Lexicon.Ma.Tokono.Byov
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = default;
 
         /// <summary>
         /// Gets or sets the id.
         /// </summary>
         [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the serviceProvider.
         /// </summary>
         [JsonPropertyName("serviceProvider")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ServiceProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the title.
         /// </summary>
         [JsonPropertyName("title")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Title { get; set; }
 
         public const string RecordType = "ma.tokono.byov.video";

--- a/src/FishyFlip/Lexicon/Social/Psky/Actor/Profile.g.cs
+++ b/src/FishyFlip/Lexicon/Social/Psky/Actor/Profile.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Social.Psky.Actor
         /// Gets or sets the nickname.
         /// </summary>
         [JsonPropertyName("nickname")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Nickname { get; set; }
 
         public const string RecordType = "social.psky.actor.profile";

--- a/src/FishyFlip/Lexicon/Social/Psky/Chat/Message.g.cs
+++ b/src/FishyFlip/Lexicon/Social/Psky/Chat/Message.g.cs
@@ -58,12 +58,14 @@ namespace FishyFlip.Lexicon.Social.Psky.Chat
         /// <br/> Text content.
         /// </summary>
         [JsonPropertyName("content")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Content { get; set; }
 
         /// <summary>
         /// Gets or sets the room.
         /// </summary>
         [JsonPropertyName("room")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATUriJsonConverter))]
         public FishyFlip.Models.ATUri? Room { get; set; }
 
@@ -72,6 +74,7 @@ namespace FishyFlip.Lexicon.Social.Psky.Chat
         /// <br/> Annotations of text (mentions, URLs, hashtags, etc)
         /// </summary>
         [JsonPropertyName("facets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Social.Psky.Richtext.Facet>? Facets { get; set; }
 
         /// <summary>
@@ -79,6 +82,7 @@ namespace FishyFlip.Lexicon.Social.Psky.Chat
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.StrongRef"/> (com.atproto.repo.strongRef)
         /// </summary>
         [JsonPropertyName("reply")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Com.Atproto.Repo.StrongRef? Reply { get; set; }
 
         public const string RecordType = "social.psky.chat.message";

--- a/src/FishyFlip/Lexicon/Social/Psky/Chat/Room.g.cs
+++ b/src/FishyFlip/Lexicon/Social/Psky/Chat/Room.g.cs
@@ -65,12 +65,14 @@ namespace FishyFlip.Lexicon.Social.Psky.Chat
         /// Gets or sets the name.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the languages.
         /// </summary>
         [JsonPropertyName("languages")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Languages { get; set; }
 
         /// <summary>
@@ -78,12 +80,14 @@ namespace FishyFlip.Lexicon.Social.Psky.Chat
         /// <br/> Topic title of the room.
         /// </summary>
         [JsonPropertyName("topic")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Topic { get; set; }
 
         /// <summary>
         /// Gets or sets the tags.
         /// </summary>
         [JsonPropertyName("tags")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Tags { get; set; }
 
         /// <summary>
@@ -92,6 +96,7 @@ namespace FishyFlip.Lexicon.Social.Psky.Chat
         /// social.psky.chat.defs#modlistRef <br/>
         /// </summary>
         [JsonPropertyName("allowlist")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Social.Psky.Chat.ModlistRef? Allowlist { get; set; }
 
         /// <summary>
@@ -100,6 +105,7 @@ namespace FishyFlip.Lexicon.Social.Psky.Chat
         /// social.psky.chat.defs#modlistRef <br/>
         /// </summary>
         [JsonPropertyName("denylist")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Social.Psky.Chat.ModlistRef? Denylist { get; set; }
 
         public const string RecordType = "social.psky.chat.room";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CreateTemplateInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CreateTemplateInput.g.cs
@@ -80,6 +80,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> Message language.
         /// </summary>
         [JsonPropertyName("lang")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Lang { get; set; }
 
         /// <summary>
@@ -87,6 +88,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> DID of the user who is creating the template.
         /// </summary>
         [JsonPropertyName("createdBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? CreatedBy { get; set; }
 

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Communication/TemplateView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Communication/TemplateView.g.cs
@@ -83,6 +83,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> Content of the template, can contain markdown and variable placeholders.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Subject { get; set; }
 
         /// <summary>
@@ -105,6 +106,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> Message language.
         /// </summary>
         [JsonPropertyName("lang")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Lang { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Communication/UpdateTemplateInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Communication/UpdateTemplateInput.g.cs
@@ -70,6 +70,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> Name of the template.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> Message language.
         /// </summary>
         [JsonPropertyName("lang")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Lang { get; set; }
 
         /// <summary>
@@ -84,6 +86,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> Content of the template, markdown supported, can contain variable placeholders.
         /// </summary>
         [JsonPropertyName("contentMarkdown")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ContentMarkdown { get; set; }
 
         /// <summary>
@@ -91,6 +94,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> Subject of the message, used in emails.
         /// </summary>
         [JsonPropertyName("subject")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Subject { get; set; }
 
         /// <summary>
@@ -98,6 +102,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// <br/> DID of the user who is updating the template.
         /// </summary>
         [JsonPropertyName("updatedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? UpdatedBy { get; set; }
 
@@ -105,6 +110,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
         /// Gets or sets the disabled.
         /// </summary>
         [JsonPropertyName("disabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Disabled { get; set; }
 
         public const string RecordType = "tools.ozone.communication.updateTemplate#UpdateTemplateInput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Hosting/AccountCreated.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Hosting/AccountCreated.g.cs
@@ -46,12 +46,14 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Hosting
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         /// <summary>
         /// Gets or sets the handle.
         /// </summary>
         [JsonPropertyName("handle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATHandleJsonConverter))]
         public FishyFlip.Models.ATHandle? Handle { get; set; }
 

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Hosting/GetAccountHistoryOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Hosting/GetAccountHistoryOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Hosting
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/AccountEvent.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/AccountEvent.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -84,6 +85,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// tombstoned <br/>
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Status { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/AccountHosting.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/AccountHosting.g.cs
@@ -78,30 +78,35 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the updatedAt.
         /// </summary>
         [JsonPropertyName("updatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? UpdatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Gets or sets the deletedAt.
         /// </summary>
         [JsonPropertyName("deletedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? DeletedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the deactivatedAt.
         /// </summary>
         [JsonPropertyName("deactivatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? DeactivatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the reactivatedAt.
         /// </summary>
         [JsonPropertyName("reactivatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? ReactivatedAt { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#accountHosting";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/AccountStats.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/AccountStats.g.cs
@@ -59,6 +59,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Total number of reports on the account
         /// </summary>
         [JsonPropertyName("reportCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ReportCount { get; set; }
 
         /// <summary>
@@ -66,6 +67,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Total number of appeals against a moderation action on the account
         /// </summary>
         [JsonPropertyName("appealCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? AppealCount { get; set; }
 
         /// <summary>
@@ -73,6 +75,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of times the account was suspended
         /// </summary>
         [JsonPropertyName("suspendCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? SuspendCount { get; set; }
 
         /// <summary>
@@ -80,6 +83,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of times the account was escalated
         /// </summary>
         [JsonPropertyName("escalateCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? EscalateCount { get; set; }
 
         /// <summary>
@@ -87,6 +91,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of times the account was taken down
         /// </summary>
         [JsonPropertyName("takedownCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? TakedownCount { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#accountStats";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/BlobView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/BlobView.g.cs
@@ -95,6 +95,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.VideoDetails"/> (tools.ozone.moderation.defs#videoDetails) <br/>
         /// </summary>
         [JsonPropertyName("details")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Details { get; set; }
 
         /// <summary>
@@ -102,6 +103,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.Moderation"/> (tools.ozone.moderation.defs#moderation)
         /// </summary>
         [JsonPropertyName("moderation")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.Moderation? Moderation { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#blobView";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/EmitEventInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/EmitEventInput.g.cs
@@ -114,6 +114,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the subjectBlobCids.
         /// </summary>
         [JsonPropertyName("subjectBlobCids")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? SubjectBlobCids { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/IdentityEvent.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/IdentityEvent.g.cs
@@ -58,12 +58,14 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
         /// Gets or sets the handle.
         /// </summary>
         [JsonPropertyName("handle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATHandleJsonConverter))]
         public FishyFlip.Models.ATHandle? Handle { get; set; }
 
@@ -71,12 +73,14 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the pdsHost.
         /// </summary>
         [JsonPropertyName("pdsHost")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? PdsHost { get; set; }
 
         /// <summary>
         /// Gets or sets the tombstone.
         /// </summary>
         [JsonPropertyName("tombstone")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Tombstone { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventAcknowledge.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventAcknowledge.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -53,6 +54,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> If true, all other reports on content authored by this account will be resolved (acknowledged).
         /// </summary>
         [JsonPropertyName("acknowledgeAccountSubjects")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AcknowledgeAccountSubjects { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventAcknowledge";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventComment.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventComment.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -56,6 +57,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Make the comment persistent on the subject
         /// </summary>
         [JsonPropertyName("sticky")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Sticky { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventComment";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventDivert.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventDivert.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventDivert";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventEmail.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventEmail.g.cs
@@ -61,6 +61,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> The content of the email sent to the user.
         /// </summary>
         [JsonPropertyName("content")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Content { get; set; }
 
         /// <summary>
@@ -68,6 +69,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Additional comment about the outgoing comm.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventEmail";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventEscalate.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventEscalate.g.cs
@@ -43,6 +43,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventEscalate";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventLabel.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventLabel.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -76,6 +77,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Indicates how long the label will remain on the subject. Only applies on labels that are being added.
         /// </summary>
         [JsonPropertyName("durationInHours")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? DurationInHours { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventLabel";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventMute.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventMute.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventMuteReporter.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventMuteReporter.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -56,6 +57,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Indicates how long the account should remain muted. Falsy value here means a permanent mute.
         /// </summary>
         [JsonPropertyName("durationInHours")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? DurationInHours { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventMuteReporter";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventPriorityScore.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventPriorityScore.g.cs
@@ -49,6 +49,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventReport.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventReport.g.cs
@@ -61,6 +61,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -68,6 +69,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Set to true if the reporter was muted from reporting at the time of the event. These reports won't impact the reviewState of the subject.
         /// </summary>
         [JsonPropertyName("isReporterMuted")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IsReporterMuted { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventResolveAppeal.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventResolveAppeal.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Describe resolution.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventResolveAppeal";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventReverseTakedown.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventReverseTakedown.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Describe reasoning behind the reversal.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventReverseTakedown";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventTag.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventTag.g.cs
@@ -69,6 +69,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Additional comment about added/removed tags.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventTag";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventTakedown.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventTakedown.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -62,6 +63,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Indicates how long the takedown should be in effect before automatically expiring.
         /// </summary>
         [JsonPropertyName("durationInHours")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? DurationInHours { get; set; }
 
         /// <summary>
@@ -69,6 +71,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> If true, all other reports on content authored by this account will be resolved (acknowledged).
         /// </summary>
         [JsonPropertyName("acknowledgeAccountSubjects")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? AcknowledgeAccountSubjects { get; set; }
 
         /// <summary>
@@ -76,6 +79,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Names/Keywords of the policies that drove the decision.
         /// </summary>
         [JsonPropertyName("policies")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Policies { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventTakedown";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventUnmute.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventUnmute.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Describe reasoning behind the reversal.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventUnmute";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventUnmuteReporter.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventUnmuteReporter.g.cs
@@ -47,6 +47,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Describe reasoning behind the reversal.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventUnmuteReporter";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModEventView.g.cs
@@ -157,12 +157,14 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the creatorHandle.
         /// </summary>
         [JsonPropertyName("creatorHandle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? CreatorHandle { get; set; }
 
         /// <summary>
         /// Gets or sets the subjectHandle.
         /// </summary>
         [JsonPropertyName("subjectHandle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SubjectHandle { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#modEventView";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/Moderation.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/Moderation.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.SubjectStatusView"/> (tools.ozone.moderation.defs#subjectStatusView)
         /// </summary>
         [JsonPropertyName("subjectStatus")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.SubjectStatusView? SubjectStatus { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#moderation";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationDetail.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationDetail.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.SubjectStatusView"/> (tools.ozone.moderation.defs#subjectStatusView)
         /// </summary>
         [JsonPropertyName("subjectStatus")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.SubjectStatusView? SubjectStatus { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#moderationDetail";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/QueryEventsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/QueryEventsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/QueryStatusesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/QueryStatusesOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordEvent.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordEvent.g.cs
@@ -60,6 +60,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the comment.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the cid.
         /// </summary>
         [JsonPropertyName("cid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cid { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordHosting.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordHosting.g.cs
@@ -66,18 +66,21 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the updatedAt.
         /// </summary>
         [JsonPropertyName("updatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? UpdatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Gets or sets the deletedAt.
         /// </summary>
         [JsonPropertyName("deletedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? DeletedAt { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#recordHosting";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordViewDetail.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordViewDetail.g.cs
@@ -97,6 +97,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordsStats.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RecordsStats.g.cs
@@ -68,6 +68,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Cumulative sum of the number of reports on the items in the set
         /// </summary>
         [JsonPropertyName("totalReports")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? TotalReports { get; set; }
 
         /// <summary>
@@ -75,6 +76,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of items that were reported at least once
         /// </summary>
         [JsonPropertyName("reportedCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ReportedCount { get; set; }
 
         /// <summary>
@@ -82,6 +84,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of items that were escalated at least once
         /// </summary>
         [JsonPropertyName("escalatedCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? EscalatedCount { get; set; }
 
         /// <summary>
@@ -89,6 +92,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of items that were appealed at least once
         /// </summary>
         [JsonPropertyName("appealedCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? AppealedCount { get; set; }
 
         /// <summary>
@@ -96,6 +100,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Total number of item in the set
         /// </summary>
         [JsonPropertyName("subjectCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? SubjectCount { get; set; }
 
         /// <summary>
@@ -103,6 +108,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of item currently in "reviewOpen" or "reviewEscalated" state
         /// </summary>
         [JsonPropertyName("pendingCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? PendingCount { get; set; }
 
         /// <summary>
@@ -110,6 +116,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of item currently in "reviewNone" or "reviewClosed" state
         /// </summary>
         [JsonPropertyName("processedCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? ProcessedCount { get; set; }
 
         /// <summary>
@@ -117,6 +124,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Number of item currently taken down
         /// </summary>
         [JsonPropertyName("takendownCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? TakendownCount { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#recordsStats";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RepoView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RepoView.g.cs
@@ -93,6 +93,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         /// <summary>
@@ -122,30 +123,35 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Server.InviteCode"/> (com.atproto.server.defs#inviteCode)
         /// </summary>
         [JsonPropertyName("invitedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Server.InviteCode? InvitedBy { get; set; }
 
         /// <summary>
         /// Gets or sets the invitesDisabled.
         /// </summary>
         [JsonPropertyName("invitesDisabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? InvitesDisabled { get; set; }
 
         /// <summary>
         /// Gets or sets the inviteNote.
         /// </summary>
         [JsonPropertyName("inviteNote")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? InviteNote { get; set; }
 
         /// <summary>
         /// Gets or sets the deactivatedAt.
         /// </summary>
         [JsonPropertyName("deactivatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? DeactivatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the threatSignatures.
         /// </summary>
         [JsonPropertyName("threatSignatures")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Admin.ThreatSignature>? ThreatSignatures { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#repoView";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RepoViewDetail.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/RepoViewDetail.g.cs
@@ -102,6 +102,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the email.
         /// </summary>
         [JsonPropertyName("email")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Email { get; set; }
 
         /// <summary>
@@ -130,6 +131,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the labels.
         /// </summary>
         [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Label.Label>? Labels { get; set; }
 
         /// <summary>
@@ -137,42 +139,49 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Com.Atproto.Server.InviteCode"/> (com.atproto.server.defs#inviteCode)
         /// </summary>
         [JsonPropertyName("invitedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Com.Atproto.Server.InviteCode? InvitedBy { get; set; }
 
         /// <summary>
         /// Gets or sets the invites.
         /// </summary>
         [JsonPropertyName("invites")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Server.InviteCode>? Invites { get; set; }
 
         /// <summary>
         /// Gets or sets the invitesDisabled.
         /// </summary>
         [JsonPropertyName("invitesDisabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? InvitesDisabled { get; set; }
 
         /// <summary>
         /// Gets or sets the inviteNote.
         /// </summary>
         [JsonPropertyName("inviteNote")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? InviteNote { get; set; }
 
         /// <summary>
         /// Gets or sets the emailConfirmedAt.
         /// </summary>
         [JsonPropertyName("emailConfirmedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? EmailConfirmedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the deactivatedAt.
         /// </summary>
         [JsonPropertyName("deactivatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? DeactivatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the threatSignatures.
         /// </summary>
         [JsonPropertyName("threatSignatures")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Com.Atproto.Admin.ThreatSignature>? ThreatSignatures { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#repoViewDetail";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/SearchReposOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/SearchReposOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/SubjectStatusView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/SubjectStatusView.g.cs
@@ -144,18 +144,21 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordHosting"/> (tools.ozone.moderation.defs#recordHosting) <br/>
         /// </summary>
         [JsonPropertyName("hosting")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Hosting { get; set; }
 
         /// <summary>
         /// Gets or sets the subjectBlobCids.
         /// </summary>
         [JsonPropertyName("subjectBlobCids")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? SubjectBlobCids { get; set; }
 
         /// <summary>
         /// Gets or sets the subjectRepoHandle.
         /// </summary>
         [JsonPropertyName("subjectRepoHandle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? SubjectRepoHandle { get; set; }
 
         /// <summary>
@@ -191,6 +194,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Sticky comment on the subject.
         /// </summary>
         [JsonPropertyName("comment")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Comment { get; set; }
 
         /// <summary>
@@ -198,24 +202,28 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Numeric value representing the level of priority. Higher score means higher priority.
         /// </summary>
         [JsonPropertyName("priorityScore")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public long? PriorityScore { get; set; }
 
         /// <summary>
         /// Gets or sets the muteUntil.
         /// </summary>
         [JsonPropertyName("muteUntil")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? MuteUntil { get; set; }
 
         /// <summary>
         /// Gets or sets the muteReportingUntil.
         /// </summary>
         [JsonPropertyName("muteReportingUntil")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? MuteReportingUntil { get; set; }
 
         /// <summary>
         /// Gets or sets the lastReviewedBy.
         /// </summary>
         [JsonPropertyName("lastReviewedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? LastReviewedBy { get; set; }
 
@@ -223,12 +231,14 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// Gets or sets the lastReviewedAt.
         /// </summary>
         [JsonPropertyName("lastReviewedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? LastReviewedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the lastReportedAt.
         /// </summary>
         [JsonPropertyName("lastReportedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? LastReportedAt { get; set; }
 
         /// <summary>
@@ -236,12 +246,14 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Timestamp referencing when the author of the subject appealed a moderation action
         /// </summary>
         [JsonPropertyName("lastAppealedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? LastAppealedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the takendown.
         /// </summary>
         [JsonPropertyName("takendown")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Takendown { get; set; }
 
         /// <summary>
@@ -249,18 +261,21 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> True indicates that the a previously taken moderator action was appealed against, by the author of the content. False indicates last appeal was resolved by moderators.
         /// </summary>
         [JsonPropertyName("appealed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Appealed { get; set; }
 
         /// <summary>
         /// Gets or sets the suspendUntil.
         /// </summary>
         [JsonPropertyName("suspendUntil")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? SuspendUntil { get; set; }
 
         /// <summary>
         /// Gets or sets the tags.
         /// </summary>
         [JsonPropertyName("tags")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? Tags { get; set; }
 
         /// <summary>
@@ -269,6 +284,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.AccountStats"/> (tools.ozone.moderation.defs#accountStats)
         /// </summary>
         [JsonPropertyName("accountStats")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.AccountStats? AccountStats { get; set; }
 
         /// <summary>
@@ -277,6 +293,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordsStats"/> (tools.ozone.moderation.defs#recordsStats)
         /// </summary>
         [JsonPropertyName("recordsStats")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordsStats? RecordsStats { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#subjectStatusView";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/SubjectView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/SubjectView.g.cs
@@ -93,6 +93,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.SubjectStatusView"/> (tools.ozone.moderation.defs#subjectStatusView)
         /// </summary>
         [JsonPropertyName("status")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.SubjectStatusView? Status { get; set; }
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail"/> (tools.ozone.moderation.defs#repoViewDetail)
         /// </summary>
         [JsonPropertyName("repo")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail? Repo { get; set; }
 
         /// <summary>
@@ -107,6 +109,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> Union Types: <br/>
         /// </summary>
         [JsonPropertyName("profile")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? Profile { get; set; }
 
         /// <summary>
@@ -114,6 +117,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail"/> (tools.ozone.moderation.defs#recordViewDetail)
         /// </summary>
         [JsonPropertyName("record")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail? Record { get; set; }
 
         public const string RecordType = "tools.ozone.moderation.defs#subjectView";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Server/GetConfigOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Server/GetConfigOutput.g.cs
@@ -69,6 +69,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// tools.ozone.server.defs#serviceConfig <br/>
         /// </summary>
         [JsonPropertyName("appview")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Server.ServiceConfig? Appview { get; set; }
 
         /// <summary>
@@ -76,6 +77,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// tools.ozone.server.defs#serviceConfig <br/>
         /// </summary>
         [JsonPropertyName("pds")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Server.ServiceConfig? Pds { get; set; }
 
         /// <summary>
@@ -83,6 +85,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// tools.ozone.server.defs#serviceConfig <br/>
         /// </summary>
         [JsonPropertyName("blobDivert")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Server.ServiceConfig? BlobDivert { get; set; }
 
         /// <summary>
@@ -90,6 +93,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// tools.ozone.server.defs#serviceConfig <br/>
         /// </summary>
         [JsonPropertyName("chat")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Server.ServiceConfig? Chat { get; set; }
 
         /// <summary>
@@ -97,6 +101,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// tools.ozone.server.defs#viewerConfig <br/>
         /// </summary>
         [JsonPropertyName("viewer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Server.ViewerConfig? Viewer { get; set; }
 
         /// <summary>
@@ -104,6 +109,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// <br/> The did of the verifier used for verification.
         /// </summary>
         [JsonPropertyName("verifierDid")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? VerifierDid { get; set; }
 

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServiceConfig.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServiceConfig.g.cs
@@ -43,6 +43,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// Gets or sets the url.
         /// </summary>
         [JsonPropertyName("url")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Url { get; set; }
 
         public const string RecordType = "tools.ozone.server.getConfig#serviceConfig";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Server/ViewerConfig.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Server/ViewerConfig.g.cs
@@ -54,6 +54,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
         /// roleVerifier - Verifier role. Only allowed to issue verifications. <br/>
         /// </summary>
         [JsonPropertyName("role")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Role { get; set; }
 
         public const string RecordType = "tools.ozone.server.getConfig#viewerConfig";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/GetValuesOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/GetValuesOutput.g.cs
@@ -66,6 +66,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         public const string RecordType = "tools.ozone.set.getValues#GetValuesOutput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/QuerySetsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/QuerySetsOutput.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         public const string RecordType = "tools.ozone.set.querySets#QuerySetsOutput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/Set.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/Set.g.cs
@@ -53,6 +53,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         public const string RecordType = "tools.ozone.set.defs#set";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetView.g.cs
@@ -62,6 +62,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/UpsertSetInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/UpsertSetInput.g.cs
@@ -32,6 +32,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
         /// <br/> <see cref="FishyFlip.Lexicon.Tools.Ozone.Set.Set"/> (tools.ozone.set.defs#set)
         /// </summary>
         [JsonPropertyName("set")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.Tools.Ozone.Set.Set? Set { get; set; }
 
         public const string RecordType = "tools.ozone.set.upsertSet#UpsertSetInput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Setting/ListOptionsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Setting/ListOptionsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Setting/Option.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Setting/Option.g.cs
@@ -102,18 +102,21 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Gets or sets the updatedAt.
         /// </summary>
         [JsonPropertyName("updatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? UpdatedAt { get; set; }
 
         /// <summary>
@@ -125,6 +128,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
         /// roleVerifier - Verifier role. Only allowed to issue verifications. <br/>
         /// </summary>
         [JsonPropertyName("managerRole")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ManagerRole { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Setting/UpsertOptionInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Setting/UpsertOptionInput.g.cs
@@ -89,6 +89,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
         /// Gets or sets the description.
         /// </summary>
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
         /// roleAdmin - Admin role. Highest level of access, can perform all actions. <br/>
         /// </summary>
         [JsonPropertyName("managerRole")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ManagerRole { get; set; }
 
         public const string RecordType = "tools.ozone.setting.upsertOption#UpsertOptionInput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Signature/FindRelatedAccountsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Signature/FindRelatedAccountsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Signature/RelatedAccount.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Signature/RelatedAccount.g.cs
@@ -56,6 +56,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
         /// Gets or sets the similarities.
         /// </summary>
         [JsonPropertyName("similarities")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<FishyFlip.Lexicon.Tools.Ozone.Signature.SigDetail>? Similarities { get; set; }
 
         public const string RecordType = "tools.ozone.signature.findRelatedAccounts#relatedAccount";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SearchAccountsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SearchAccountsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Team/ListMembersOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Team/ListMembersOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Team/Member.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Team/Member.g.cs
@@ -77,6 +77,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         /// Gets or sets the disabled.
         /// </summary>
         [JsonPropertyName("disabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Disabled { get; set; }
 
         /// <summary>
@@ -84,24 +85,28 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         /// <br/> <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed"/> (app.bsky.actor.defs#profileViewDetailed)
         /// </summary>
         [JsonPropertyName("profile")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed? Profile { get; set; }
 
         /// <summary>
         /// Gets or sets the createdAt.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Gets or sets the updatedAt.
         /// </summary>
         [JsonPropertyName("updatedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? UpdatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the lastUpdatedBy.
         /// </summary>
         [JsonPropertyName("lastUpdatedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? LastUpdatedBy { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Team/UpdateMemberInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Team/UpdateMemberInput.g.cs
@@ -63,6 +63,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         /// Gets or sets the disabled.
         /// </summary>
         [JsonPropertyName("disabled")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Disabled { get; set; }
 
         /// <summary>
@@ -74,6 +75,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
         /// roleTriage - Triage role. Mostly intended for monitoring and escalating issues. <br/>
         /// </summary>
         [JsonPropertyName("role")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Role { get; set; }
 
         public const string RecordType = "tools.ozone.team.updateMember#UpdateMemberInput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Verification/ListVerificationsOutput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Verification/ListVerificationsOutput.g.cs
@@ -46,6 +46,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// Gets or sets the cursor.
         /// </summary>
         [JsonPropertyName("cursor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Cursor { get; set; }
 
         /// <summary>

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Verification/RevokeVerificationsInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Verification/RevokeVerificationsInput.g.cs
@@ -55,6 +55,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <br/> Reason for revoking the verification. This is optional and can be omitted if not needed.
         /// </summary>
         [JsonPropertyName("revokeReason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RevokeReason { get; set; }
 
         public const string RecordType = "tools.ozone.verification.revokeVerifications#RevokeVerificationsInput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Verification/VerificationInput.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Verification/VerificationInput.g.cs
@@ -79,6 +79,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <br/> Timestamp for verification record. Defaults to current time when not specified.
         /// </summary>
         [JsonPropertyName("createdAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? CreatedAt { get; set; } = DateTime.UtcNow;
 
         public const string RecordType = "tools.ozone.verification.grantVerifications#verificationInput";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Verification/VerificationView.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Verification/VerificationView.g.cs
@@ -147,6 +147,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <br/> Describes the reason for revocation, also indicating that the verification is no longer valid.
         /// </summary>
         [JsonPropertyName("revokeReason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RevokeReason { get; set; }
 
         /// <summary>
@@ -154,6 +155,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <br/> Timestamp when the verification was revoked.
         /// </summary>
         [JsonPropertyName("revokedAt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public DateTime? RevokedAt { get; set; }
 
         /// <summary>
@@ -161,6 +163,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <br/> The user who revoked this verification.
         /// </summary>
         [JsonPropertyName("revokedBy")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonConverter(typeof(FishyFlip.Tools.Json.ATDidJsonConverter))]
         public FishyFlip.Models.ATDid? RevokedBy { get; set; }
 
@@ -169,6 +172,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <br/> Union Types: <br/>
         /// </summary>
         [JsonPropertyName("subjectProfile")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? SubjectProfile { get; set; }
 
         /// <summary>
@@ -176,6 +180,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <br/> Union Types: <br/>
         /// </summary>
         [JsonPropertyName("issuerProfile")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? IssuerProfile { get; set; }
 
         /// <summary>
@@ -185,6 +190,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewNotFound"/> (tools.ozone.moderation.defs#repoViewNotFound) <br/>
         /// </summary>
         [JsonPropertyName("subjectRepo")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? SubjectRepo { get; set; }
 
         /// <summary>
@@ -194,6 +200,7 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
         /// <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewNotFound"/> (tools.ozone.moderation.defs#repoViewNotFound) <br/>
         /// </summary>
         [JsonPropertyName("issuerRepo")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ATObject? IssuerRepo { get; set; }
 
         public const string RecordType = "tools.ozone.verification.defs#verificationView";

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -2649,6 +2649,10 @@ public partial class AppCommands
         {
             sb.AppendLine("        [JsonRequired]");
         }
+        else
+        {
+            sb.AppendLine("        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]");
+        }
 
         if (property.PropertyDefinition.Type == "array" && !property.IsBaseType)
         {


### PR DESCRIPTION
Fixes #271 

This rebinds the optional object fields to ignore them from being written as JSON when null. The options are set in the SourceGenerationContext to do that, but for reasons I'm unsure about that doesn't seem to apply to ASP.NET, and nothing I set beyond forcing it this way will let it do it.

The converters do seem to run fine when parsed, it's just not these options. It's weird.