### PR TITLE
[XRPC] Add ATResult

### DIFF
--- a/src/FishyFlip.Xrpc/ATResult.cs
+++ b/src/FishyFlip.Xrpc/ATResult.cs
@@ -1,0 +1,47 @@
+// <copyright file="ATResult.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace FishyFlip.Models;
+
+/// <summary>
+/// Represents the result of an ATProto XRPC operation.
+/// </summary>
+/// <typeparam name="T">The type of the result data.</typeparam>
+public class ATResult<T> : IResult
+    where T : ATObject
+{
+    private int statusCode = 200;
+
+    private T? data;
+
+    /// <summary>
+    /// Ok result with status code 200 and at ATObject.
+    /// </summary>
+    /// <param name="data">The data.</param>
+    /// <returns><see cref="ATResult"/>.</returns>
+    public static ATResult<T> Ok(T? data)
+    {
+        return new ATResult<T>
+        {
+            statusCode = 200,
+            data = data,
+        };
+    }
+
+    /// <inheritdoc/>
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        httpContext.Response.StatusCode = this.statusCode;
+        if (this.data != null)
+        {
+            httpContext.Response.ContentType = "application/json";
+            return httpContext.Response.WriteAsync(this.data.ToJson());
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Actor/ActorController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Actor/ActorController.g.cs
@@ -21,7 +21,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Actor.GetPreferencesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.actor.getPreferences")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Actor.GetPreferencesOutput>, ATErrorResult>> GetPreferencesAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Actor.GetPreferencesOutput>, ATErrorResult>> GetPreferencesAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get detailed profile view of an actor. Does not require auth, but contains relevant metadata with auth.
@@ -30,7 +30,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed"/></returns>
         [HttpGet("/xrpc/app.bsky.actor.getProfile")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed>, ATErrorResult>> GetProfileAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Actor.ProfileViewDetailed>, ATErrorResult>> GetProfileAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get detailed profile views of multiple actors.
@@ -39,7 +39,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Actor.GetProfilesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.actor.getProfiles")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Actor.GetProfilesOutput>, ATErrorResult>> GetProfilesAsync ([FromQuery] List<FishyFlip.Models.ATIdentifier> actors, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Actor.GetProfilesOutput>, ATErrorResult>> GetProfilesAsync ([FromQuery] List<FishyFlip.Models.ATIdentifier> actors, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of suggested actors. Expected use is discovery of accounts to follow during new account onboarding.
@@ -49,7 +49,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Actor.GetSuggestionsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.actor.getSuggestions")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Actor.GetSuggestionsOutput>, ATErrorResult>> GetSuggestionsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Actor.GetSuggestionsOutput>, ATErrorResult>> GetSuggestionsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Set the private preferences attached to the account.
@@ -85,7 +85,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.actor.searchActors")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsOutput>, ATErrorResult>> SearchActorsAsync ([FromQuery] string? q = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsOutput>, ATErrorResult>> SearchActorsAsync ([FromQuery] string? q = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find actor suggestions for a prefix search term. Expected use is for auto-completion during text field entry. Does not require auth.
@@ -95,7 +95,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsTypeaheadOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.actor.searchActorsTypeahead")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsTypeaheadOutput>, ATErrorResult>> SearchActorsTypeaheadAsync ([FromQuery] string? q = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Actor.SearchActorsTypeaheadOutput>, ATErrorResult>> SearchActorsTypeaheadAsync ([FromQuery] string? q = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Feed/FeedController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Feed/FeedController.g.cs
@@ -21,7 +21,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.DescribeFeedGeneratorOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.describeFeedGenerator")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.DescribeFeedGeneratorOutput>, ATErrorResult>> DescribeFeedGeneratorAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.DescribeFeedGeneratorOutput>, ATErrorResult>> DescribeFeedGeneratorAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of feeds (feed generator records) created by the actor (in the actor's repo).
@@ -32,7 +32,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetActorFeedsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getActorFeeds")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetActorFeedsOutput>, ATErrorResult>> GetActorFeedsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetActorFeedsOutput>, ATErrorResult>> GetActorFeedsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of posts liked by an actor. Requires auth, actor must be the requesting account.
@@ -46,7 +46,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetActorLikesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getActorLikes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetActorLikesOutput>, ATErrorResult>> GetActorLikesAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetActorLikesOutput>, ATErrorResult>> GetActorLikesAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a view of an actor's 'author feed' (post and reposts by the author). Does not require auth.
@@ -62,7 +62,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetAuthorFeedOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getAuthorFeed")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetAuthorFeedOutput>, ATErrorResult>> GetAuthorFeedAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? filter = default, [FromQuery] bool? includePins = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetAuthorFeedOutput>, ATErrorResult>> GetAuthorFeedAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? filter = default, [FromQuery] bool? includePins = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a hydrated feed from an actor's selected feed generator. Implemented by App View.
@@ -75,7 +75,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetFeedOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getFeed")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedOutput>, ATErrorResult>> GetFeedAsync ([FromQuery] FishyFlip.Models.ATUri feed, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedOutput>, ATErrorResult>> GetFeedAsync ([FromQuery] FishyFlip.Models.ATUri feed, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get information about a feed generator. Implemented by AppView.
@@ -84,7 +84,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getFeedGenerator")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorOutput>, ATErrorResult>> GetFeedGeneratorAsync ([FromQuery] FishyFlip.Models.ATUri feed, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorOutput>, ATErrorResult>> GetFeedGeneratorAsync ([FromQuery] FishyFlip.Models.ATUri feed, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get information about a list of feed generators.
@@ -93,7 +93,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getFeedGenerators")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorsOutput>, ATErrorResult>> GetFeedGeneratorsAsync ([FromQuery] List<FishyFlip.Models.ATUri> feeds, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedGeneratorsOutput>, ATErrorResult>> GetFeedGeneratorsAsync ([FromQuery] List<FishyFlip.Models.ATUri> feeds, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a skeleton of a feed provided by a feed generator. Auth is optional, depending on provider requirements, and provides the DID of the requester. Implemented by Feed Generator Service.
@@ -106,7 +106,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetFeedSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getFeedSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedSkeletonOutput>, ATErrorResult>> GetFeedSkeletonAsync ([FromQuery] FishyFlip.Models.ATUri feed, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetFeedSkeletonOutput>, ATErrorResult>> GetFeedSkeletonAsync ([FromQuery] FishyFlip.Models.ATUri feed, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get like records which reference a subject (by AT-URI and CID).
@@ -118,7 +118,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetLikesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getLikes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetLikesOutput>, ATErrorResult>> GetLikesAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetLikesOutput>, ATErrorResult>> GetLikesAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a feed of recent posts from a list (posts and reposts from any actors on the list). Does not require auth.
@@ -131,7 +131,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetListFeedOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getListFeed")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetListFeedOutput>, ATErrorResult>> GetListFeedAsync ([FromQuery] FishyFlip.Models.ATUri list, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetListFeedOutput>, ATErrorResult>> GetListFeedAsync ([FromQuery] FishyFlip.Models.ATUri list, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.
@@ -140,7 +140,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetPostsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getPosts")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetPostsOutput>, ATErrorResult>> GetPostsAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetPostsOutput>, ATErrorResult>> GetPostsAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get posts in a thread. Does not require auth, but additional metadata and filtering will be applied for authed requests.
@@ -153,7 +153,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetPostThreadOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getPostThread")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetPostThreadOutput>, ATErrorResult>> GetPostThreadAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] int? depth = 6, [FromQuery] int? parentHeight = 80, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetPostThreadOutput>, ATErrorResult>> GetPostThreadAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] int? depth = 6, [FromQuery] int? parentHeight = 80, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of quotes for a given post.
@@ -165,7 +165,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetQuotesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getQuotes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetQuotesOutput>, ATErrorResult>> GetQuotesAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetQuotesOutput>, ATErrorResult>> GetQuotesAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of reposts for a given post.
@@ -177,7 +177,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetRepostedByOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getRepostedBy")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetRepostedByOutput>, ATErrorResult>> GetRepostedByAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetRepostedByOutput>, ATErrorResult>> GetRepostedByAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of suggested feeds (feed generators) for the requesting account.
@@ -187,7 +187,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetSuggestedFeedsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getSuggestedFeeds")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetSuggestedFeedsOutput>, ATErrorResult>> GetSuggestedFeedsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetSuggestedFeedsOutput>, ATErrorResult>> GetSuggestedFeedsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a view of the requesting account's home timeline. This is expected to be some form of reverse-chronological feed.
@@ -198,7 +198,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.GetTimelineOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.getTimeline")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.GetTimelineOutput>, ATErrorResult>> GetTimelineAsync ([FromQuery] string? algorithm = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.GetTimelineOutput>, ATErrorResult>> GetTimelineAsync ([FromQuery] string? algorithm = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find posts matching search criteria, returning views of those posts.
@@ -220,7 +220,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.SearchPostsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.feed.searchPosts")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.SearchPostsOutput>, ATErrorResult>> SearchPostsAsync ([FromQuery] string q, [FromQuery] string? sort = default, [FromQuery] string? since = default, [FromQuery] string? until = default, [FromQuery] FishyFlip.Models.ATIdentifier? mentions = default, [FromQuery] FishyFlip.Models.ATIdentifier? author = default, [FromQuery] string? lang = default, [FromQuery] string? domain = default, [FromQuery] string? url = default, [FromQuery] List<string>? tag = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.SearchPostsOutput>, ATErrorResult>> SearchPostsAsync ([FromQuery] string q, [FromQuery] string? sort = default, [FromQuery] string? since = default, [FromQuery] string? until = default, [FromQuery] FishyFlip.Models.ATIdentifier? mentions = default, [FromQuery] FishyFlip.Models.ATIdentifier? author = default, [FromQuery] string? lang = default, [FromQuery] string? domain = default, [FromQuery] string? url = default, [FromQuery] List<string>? tag = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Send information about interactions with feed items back to the feed generator that served them.
@@ -229,7 +229,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput"/></returns>
         [HttpPost("/xrpc/app.bsky.feed.sendInteractions")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput>, ATErrorResult>> SendInteractionsAsync ([FromBody] FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsOutput>, ATErrorResult>> SendInteractionsAsync ([FromBody] FishyFlip.Lexicon.App.Bsky.Feed.SendInteractionsInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Graph/GraphController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Graph/GraphController.g.cs
@@ -24,7 +24,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetActorStarterPacksOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getActorStarterPacks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetActorStarterPacksOutput>, ATErrorResult>> GetActorStarterPacksAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetActorStarterPacksOutput>, ATErrorResult>> GetActorStarterPacksAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates which accounts the requesting account is currently blocking. Requires auth.
@@ -34,7 +34,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetBlocksOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getBlocks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetBlocksOutput>, ATErrorResult>> GetBlocksAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetBlocksOutput>, ATErrorResult>> GetBlocksAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates accounts which follow a specified account (actor).
@@ -45,7 +45,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetFollowersOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getFollowers")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowersOutput>, ATErrorResult>> GetFollowersAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowersOutput>, ATErrorResult>> GetFollowersAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates accounts which a specified account (actor) follows.
@@ -56,7 +56,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetFollowsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getFollows")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowsOutput>, ATErrorResult>> GetFollowsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetFollowsOutput>, ATErrorResult>> GetFollowsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates accounts which follow a specified account (actor) and are followed by the viewer.
@@ -67,7 +67,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetKnownFollowersOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getKnownFollowers")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetKnownFollowersOutput>, ATErrorResult>> GetKnownFollowersAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetKnownFollowersOutput>, ATErrorResult>> GetKnownFollowersAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a 'view' (with additional context) of a specified list.
@@ -78,7 +78,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetListOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getList")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetListOutput>, ATErrorResult>> GetListAsync ([FromQuery] FishyFlip.Models.ATUri list, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetListOutput>, ATErrorResult>> GetListAsync ([FromQuery] FishyFlip.Models.ATUri list, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get mod lists that the requesting account (actor) is blocking. Requires auth.
@@ -88,7 +88,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetListBlocksOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getListBlocks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetListBlocksOutput>, ATErrorResult>> GetListBlocksAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetListBlocksOutput>, ATErrorResult>> GetListBlocksAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates mod lists that the requesting account (actor) currently has muted. Requires auth.
@@ -98,7 +98,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetListMutesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getListMutes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetListMutesOutput>, ATErrorResult>> GetListMutesAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetListMutesOutput>, ATErrorResult>> GetListMutesAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates the lists created by a specified account (actor).
@@ -109,7 +109,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetListsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getLists")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetListsOutput>, ATErrorResult>> GetListsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetListsOutput>, ATErrorResult>> GetListsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates accounts that the requesting account (actor) currently has muted. Requires auth.
@@ -119,7 +119,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetMutesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getMutes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetMutesOutput>, ATErrorResult>> GetMutesAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetMutesOutput>, ATErrorResult>> GetMutesAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates public relationships between one account, and a list of other accounts. Does not require auth.
@@ -131,7 +131,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetRelationshipsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getRelationships")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetRelationshipsOutput>, ATErrorResult>> GetRelationshipsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] List<FishyFlip.Models.ATIdentifier>? others = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetRelationshipsOutput>, ATErrorResult>> GetRelationshipsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] List<FishyFlip.Models.ATIdentifier>? others = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a view of a starter pack.
@@ -140,7 +140,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPackOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getStarterPack")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPackOutput>, ATErrorResult>> GetStarterPackAsync ([FromQuery] FishyFlip.Models.ATUri starterPack, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPackOutput>, ATErrorResult>> GetStarterPackAsync ([FromQuery] FishyFlip.Models.ATUri starterPack, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get views for a list of starter packs.
@@ -149,7 +149,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPacksOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getStarterPacks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPacksOutput>, ATErrorResult>> GetStarterPacksAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetStarterPacksOutput>, ATErrorResult>> GetStarterPacksAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates follows similar to a given account (actor). Expected use is to recommend additional accounts immediately after following one account.
@@ -158,7 +158,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.GetSuggestedFollowsByActorOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.getSuggestedFollowsByActor")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.GetSuggestedFollowsByActorOutput>, ATErrorResult>> GetSuggestedFollowsByActorAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.GetSuggestedFollowsByActorOutput>, ATErrorResult>> GetSuggestedFollowsByActorAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a mute relationship for the specified account. Mutes are private in Bluesky. Requires auth.
@@ -196,7 +196,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Graph
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Graph.SearchStarterPacksOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.graph.searchStarterPacks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Graph.SearchStarterPacksOutput>, ATErrorResult>> SearchStarterPacksAsync ([FromQuery] string q, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Graph.SearchStarterPacksOutput>, ATErrorResult>> SearchStarterPacksAsync ([FromQuery] string q, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unmutes the specified account. Requires auth.

--- a/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Labeler/LabelerController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Labeler/LabelerController.g.cs
@@ -23,7 +23,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Labeler
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Labeler.GetServicesOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.labeler.getServices")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Labeler.GetServicesOutput>, ATErrorResult>> GetServicesAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, [FromQuery] bool? detailed = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Labeler.GetServicesOutput>, ATErrorResult>> GetServicesAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, [FromQuery] bool? detailed = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Notification/NotificationController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Notification/NotificationController.g.cs
@@ -23,7 +23,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Notification
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Notification.GetUnreadCountOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.notification.getUnreadCount")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Notification.GetUnreadCountOutput>, ATErrorResult>> GetUnreadCountAsync ([FromQuery] bool? priority = default, [FromQuery] DateTime? seenAt = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Notification.GetUnreadCountOutput>, ATErrorResult>> GetUnreadCountAsync ([FromQuery] bool? priority = default, [FromQuery] DateTime? seenAt = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerate notifications for the requesting account. Requires auth.
@@ -36,7 +36,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Notification
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Notification.ListNotificationsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.notification.listNotifications")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Notification.ListNotificationsOutput>, ATErrorResult>> ListNotificationsAsync ([FromQuery] List<string>? reasons = default, [FromQuery] int? limit = 50, [FromQuery] bool? priority = default, [FromQuery] string? cursor = default, [FromQuery] DateTime? seenAt = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Notification.ListNotificationsOutput>, ATErrorResult>> ListNotificationsAsync ([FromQuery] List<string>? reasons = default, [FromQuery] int? limit = 50, [FromQuery] bool? priority = default, [FromQuery] string? cursor = default, [FromQuery] DateTime? seenAt = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Set notification-related preferences for an account. Requires auth.

--- a/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Unspecced/UnspeccedController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Unspecced/UnspeccedController.g.cs
@@ -21,7 +21,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetConfigOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getConfig")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetConfigOutput>, ATErrorResult>> GetConfigAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetConfigOutput>, ATErrorResult>> GetConfigAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// An unspecced view of globally popular feed generators.
@@ -32,7 +32,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetPopularFeedGeneratorsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getPopularFeedGenerators")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetPopularFeedGeneratorsOutput>, ATErrorResult>> GetPopularFeedGeneratorsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? query = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetPopularFeedGeneratorsOutput>, ATErrorResult>> GetPopularFeedGeneratorsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? query = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of suggested feeds
@@ -41,7 +41,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedFeedsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getSuggestedFeeds")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedFeedsOutput>, ATErrorResult>> GetSuggestedFeedsAsync ([FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedFeedsOutput>, ATErrorResult>> GetSuggestedFeedsAsync ([FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a skeleton of suggested feeds. Intended to be called and hydrated by app.bsky.unspecced.getSuggestedFeeds
@@ -51,7 +51,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedFeedsSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getSuggestedFeedsSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedFeedsSkeletonOutput>, ATErrorResult>> GetSuggestedFeedsSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedFeedsSkeletonOutput>, ATErrorResult>> GetSuggestedFeedsSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of suggested starterpacks
@@ -60,7 +60,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedStarterPacksOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getSuggestedStarterPacks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedStarterPacksOutput>, ATErrorResult>> GetSuggestedStarterPacksAsync ([FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedStarterPacksOutput>, ATErrorResult>> GetSuggestedStarterPacksAsync ([FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a skeleton of suggested starterpacks. Intended to be called and hydrated by app.bsky.unspecced.getSuggestedStarterpacks
@@ -70,7 +70,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedStarterPacksSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getSuggestedStarterPacksSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedStarterPacksSkeletonOutput>, ATErrorResult>> GetSuggestedStarterPacksSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedStarterPacksSkeletonOutput>, ATErrorResult>> GetSuggestedStarterPacksSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of suggested users
@@ -80,7 +80,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedUsersOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getSuggestedUsers")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedUsersOutput>, ATErrorResult>> GetSuggestedUsersAsync ([FromQuery] string? category = default, [FromQuery] int? limit = 25, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedUsersOutput>, ATErrorResult>> GetSuggestedUsersAsync ([FromQuery] string? category = default, [FromQuery] int? limit = 25, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a skeleton of suggested users. Intended to be called and hydrated by app.bsky.unspecced.getSuggestedUsers
@@ -91,7 +91,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedUsersSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getSuggestedUsersSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedUsersSkeletonOutput>, ATErrorResult>> GetSuggestedUsersSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] string? category = default, [FromQuery] int? limit = 25, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestedUsersSkeletonOutput>, ATErrorResult>> GetSuggestedUsersSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] string? category = default, [FromQuery] int? limit = 25, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a skeleton of suggested actors. Intended to be called and then hydrated through app.bsky.actor.getSuggestions
@@ -103,7 +103,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestionsSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getSuggestionsSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestionsSkeletonOutput>, ATErrorResult>> GetSuggestionsSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] FishyFlip.Models.ATDid? relativeToDid = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetSuggestionsSkeletonOutput>, ATErrorResult>> GetSuggestionsSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] FishyFlip.Models.ATDid? relativeToDid = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of suggestions (feeds and users) tagged with categories
@@ -111,7 +111,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetTaggedSuggestionsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getTaggedSuggestions")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTaggedSuggestionsOutput>, ATErrorResult>> GetTaggedSuggestionsAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTaggedSuggestionsOutput>, ATErrorResult>> GetTaggedSuggestionsAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a list of trending topics
@@ -121,7 +121,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendingTopicsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getTrendingTopics")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendingTopicsOutput>, ATErrorResult>> GetTrendingTopicsAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendingTopicsOutput>, ATErrorResult>> GetTrendingTopicsAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the current trends on the network
@@ -130,7 +130,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getTrends")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendsOutput>, ATErrorResult>> GetTrendsAsync ([FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendsOutput>, ATErrorResult>> GetTrendsAsync ([FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the skeleton of trends on the network. Intended to be called and then hydrated through app.bsky.unspecced.getTrends
@@ -140,7 +140,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendsSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.getTrendsSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendsSkeletonOutput>, ATErrorResult>> GetTrendsSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.GetTrendsSkeletonOutput>, ATErrorResult>> GetTrendsSkeletonAsync ([FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 10, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Backend Actors (profile) search, returns only skeleton.
@@ -155,7 +155,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.SearchActorsSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.searchActorsSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchActorsSkeletonOutput>, ATErrorResult>> SearchActorsSkeletonAsync ([FromQuery] string q, [FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] bool? typeahead = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchActorsSkeletonOutput>, ATErrorResult>> SearchActorsSkeletonAsync ([FromQuery] string q, [FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] bool? typeahead = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Backend Posts search, returns only skeleton
@@ -178,7 +178,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.SearchPostsSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.searchPostsSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchPostsSkeletonOutput>, ATErrorResult>> SearchPostsSkeletonAsync ([FromQuery] string q, [FromQuery] string? sort = default, [FromQuery] string? since = default, [FromQuery] string? until = default, [FromQuery] FishyFlip.Models.ATIdentifier? mentions = default, [FromQuery] FishyFlip.Models.ATIdentifier? author = default, [FromQuery] string? lang = default, [FromQuery] string? domain = default, [FromQuery] string? url = default, [FromQuery] List<string>? tag = default, [FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchPostsSkeletonOutput>, ATErrorResult>> SearchPostsSkeletonAsync ([FromQuery] string q, [FromQuery] string? sort = default, [FromQuery] string? since = default, [FromQuery] string? until = default, [FromQuery] FishyFlip.Models.ATIdentifier? mentions = default, [FromQuery] FishyFlip.Models.ATIdentifier? author = default, [FromQuery] string? lang = default, [FromQuery] string? domain = default, [FromQuery] string? url = default, [FromQuery] List<string>? tag = default, [FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Backend Starter Pack search, returns only skeleton.
@@ -192,7 +192,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Unspecced
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Unspecced.SearchStarterPacksSkeletonOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.unspecced.searchStarterPacksSkeleton")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchStarterPacksSkeletonOutput>, ATErrorResult>> SearchStarterPacksSkeletonAsync ([FromQuery] string q, [FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Unspecced.SearchStarterPacksSkeletonOutput>, ATErrorResult>> SearchStarterPacksSkeletonAsync ([FromQuery] string q, [FromQuery] FishyFlip.Models.ATDid? viewer = default, [FromQuery] int? limit = 25, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Video/VideoController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/App/Bsky/Video/VideoController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Video
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Video.GetJobStatusOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.video.getJobStatus")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Video.GetJobStatusOutput>, ATErrorResult>> GetJobStatusAsync ([FromQuery] string jobId, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Video.GetJobStatusOutput>, ATErrorResult>> GetJobStatusAsync ([FromQuery] string jobId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get video upload limits for the authenticated user.
@@ -30,7 +30,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Video
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Video.GetUploadLimitsOutput"/></returns>
         [HttpGet("/xrpc/app.bsky.video.getUploadLimits")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Video.GetUploadLimitsOutput>, ATErrorResult>> GetUploadLimitsAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Video.GetUploadLimitsOutput>, ATErrorResult>> GetUploadLimitsAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Upload a video to be processed then stored on the PDS.
@@ -39,7 +39,7 @@ namespace FishyFlip.Xrpc.Lexicon.App.Bsky.Video
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput"/></returns>
         [HttpPost("/xrpc/app.bsky.video.uploadVideo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput>, ATErrorResult>> UploadVideoAsync ([FromBody] StreamContent content, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.App.Bsky.Video.UploadVideoOutput>, ATErrorResult>> UploadVideoAsync ([FromBody] StreamContent content, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Blue/Maril/Stellar/StellarController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Blue/Maril/Stellar/StellarController.g.cs
@@ -24,7 +24,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Maril.Stellar
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Maril.Stellar.GetActorReactionsOutput"/></returns>
         [HttpGet("/xrpc/blue.maril.stellar.getActorReactions")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Maril.Stellar.GetActorReactionsOutput>, ATErrorResult>> GetActorReactionsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Maril.Stellar.GetActorReactionsOutput>, ATErrorResult>> GetActorReactionsAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Return all Bluemoji in the AppView.
@@ -35,7 +35,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Maril.Stellar
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Maril.Stellar.GetEmojisOutput"/></returns>
         [HttpGet("/xrpc/blue.maril.stellar.getEmojis")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Maril.Stellar.GetEmojisOutput>, ATErrorResult>> GetEmojisAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] FishyFlip.Models.ATIdentifier? did = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Maril.Stellar.GetEmojisOutput>, ATErrorResult>> GetEmojisAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] FishyFlip.Models.ATIdentifier? did = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get reaction records which reference a subject (by AT-URI and CID).
@@ -47,7 +47,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Maril.Stellar
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Maril.Stellar.GetReactionsOutput"/></returns>
         [HttpGet("/xrpc/blue.maril.stellar.getReactions")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Maril.Stellar.GetReactionsOutput>, ATErrorResult>> GetReactionsAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Maril.Stellar.GetReactionsOutput>, ATErrorResult>> GetReactionsAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Blue/Moji/Collection/CollectionController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Blue/Moji/Collection/CollectionController.g.cs
@@ -23,7 +23,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Moji.Collection
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Moji.Collection.GetItemOutput"/></returns>
         [HttpGet("/xrpc/blue.moji.collection.getItem")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Moji.Collection.GetItemOutput>, ATErrorResult>> GetItemAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, [FromQuery] string name, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Moji.Collection.GetItemOutput>, ATErrorResult>> GetItemAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, [FromQuery] string name, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// List a range of Bluemoji in a repository, matching a specific collection. Requires auth.
@@ -34,7 +34,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Moji.Collection
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Moji.Collection.ListCollectionOutput"/></returns>
         [HttpGet("/xrpc/blue.moji.collection.listCollection")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Moji.Collection.ListCollectionOutput>, ATErrorResult>> ListCollectionAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] bool? reverse = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Moji.Collection.ListCollectionOutput>, ATErrorResult>> ListCollectionAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] bool? reverse = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a Bluemoji record, creating or updating it as needed. Requires auth, implemented by AppView.
@@ -45,7 +45,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Moji.Collection
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Moji.Collection.PutItemOutput"/></returns>
         [HttpPost("/xrpc/blue.moji.collection.putItem")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Moji.Collection.PutItemOutput>, ATErrorResult>> PutItemAsync ([FromBody] FishyFlip.Lexicon.Blue.Moji.Collection.PutItemInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Moji.Collection.PutItemOutput>, ATErrorResult>> PutItemAsync ([FromBody] FishyFlip.Lexicon.Blue.Moji.Collection.PutItemInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Copy a single emoji from another repo. Requires auth.
@@ -59,7 +59,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Moji.Collection
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Moji.Collection.SaveToCollectionOutput"/></returns>
         [HttpPost("/xrpc/blue.moji.collection.saveToCollection")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Moji.Collection.SaveToCollectionOutput>, ATErrorResult>> SaveToCollectionAsync ([FromBody] FishyFlip.Lexicon.Blue.Moji.Collection.SaveToCollectionInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Moji.Collection.SaveToCollectionOutput>, ATErrorResult>> SaveToCollectionAsync ([FromBody] FishyFlip.Lexicon.Blue.Moji.Collection.SaveToCollectionInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Blue/Moji/Packs/PacksController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Blue/Moji/Packs/PacksController.g.cs
@@ -24,7 +24,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Moji.Packs
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Moji.Packs.GetActorPacksOutput"/></returns>
         [HttpGet("/xrpc/blue.moji.packs.getActorPacks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Moji.Packs.GetActorPacksOutput>, ATErrorResult>> GetActorPacksAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Moji.Packs.GetActorPacksOutput>, ATErrorResult>> GetActorPacksAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a 'view' (with additional context) of a specified pack.
@@ -35,7 +35,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Moji.Packs
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Moji.Packs.GetPackOutput"/></returns>
         [HttpGet("/xrpc/blue.moji.packs.getPack")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Moji.Packs.GetPackOutput>, ATErrorResult>> GetPackAsync ([FromQuery] FishyFlip.Models.ATUri pack, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Moji.Packs.GetPackOutput>, ATErrorResult>> GetPackAsync ([FromQuery] FishyFlip.Models.ATUri pack, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get views for a list of Bluemoji packs.
@@ -44,7 +44,7 @@ namespace FishyFlip.Xrpc.Lexicon.Blue.Moji.Packs
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Blue.Moji.Packs.GetPacksOutput"/></returns>
         [HttpGet("/xrpc/blue.moji.packs.getPacks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Blue.Moji.Packs.GetPacksOutput>, ATErrorResult>> GetPacksAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Blue.Moji.Packs.GetPacksOutput>, ATErrorResult>> GetPacksAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Buzz/Bookhive/BookhiveController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Buzz/Bookhive/BookhiveController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Buzz.Bookhive
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Buzz.Bookhive.GetBookOutput"/></returns>
         [HttpGet("/xrpc/buzz.bookhive.getBook")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Buzz.Bookhive.GetBookOutput>, ATErrorResult>> GetBookAsync ([FromQuery] string id, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Buzz.Bookhive.GetBookOutput>, ATErrorResult>> GetBookAsync ([FromQuery] string id, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a profile's info. Does not require authentication.
@@ -32,7 +32,7 @@ namespace FishyFlip.Xrpc.Lexicon.Buzz.Bookhive
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Buzz.Bookhive.GetProfileOutput"/></returns>
         [HttpGet("/xrpc/buzz.bookhive.getProfile")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Buzz.Bookhive.GetProfileOutput>, ATErrorResult>> GetProfileAsync ([FromQuery] string? did = default, [FromQuery] string? handle = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Buzz.Bookhive.GetProfileOutput>, ATErrorResult>> GetProfileAsync ([FromQuery] string? did = default, [FromQuery] string? handle = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find books matching the search criteria. Requires authentication.
@@ -44,7 +44,7 @@ namespace FishyFlip.Xrpc.Lexicon.Buzz.Bookhive
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Buzz.Bookhive.SearchBooksOutput"/></returns>
         [HttpGet("/xrpc/buzz.bookhive.searchBooks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Buzz.Bookhive.SearchBooksOutput>, ATErrorResult>> SearchBooksAsync ([FromQuery] string q, [FromQuery] int? limit = 25, [FromQuery] int? offset = 0, [FromQuery] string? id = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Buzz.Bookhive.SearchBooksOutput>, ATErrorResult>> SearchBooksAsync ([FromQuery] string q, [FromQuery] int? limit = 25, [FromQuery] int? offset = 0, [FromQuery] string? id = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Chat/Bsky/Actor/ActorController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Chat/Bsky/Actor/ActorController.g.cs
@@ -21,7 +21,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.actor.deleteAccount")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput>, ATErrorResult>> DeleteAccountAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Actor.DeleteAccountOutput>, ATErrorResult>> DeleteAccountAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 

--- a/src/FishyFlip.Xrpc/Lexicon/Chat/Bsky/Convo/ConvoController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Chat/Bsky/Convo/ConvoController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.AcceptConvoOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.acceptConvo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.AcceptConvoOutput>, ATErrorResult>> AcceptConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.AcceptConvoInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.AcceptConvoOutput>, ATErrorResult>> AcceptConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.AcceptConvoInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adds an emoji reaction to a message. Requires authentication. It is idempotent, so multiple calls from the same user with the same emoji result in a single reaction.
@@ -37,7 +37,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.AddReactionOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.addReaction")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.AddReactionOutput>, ATErrorResult>> AddReactionAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.AddReactionInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.AddReactionOutput>, ATErrorResult>> AddReactionAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.AddReactionInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -47,7 +47,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.deleteMessageForSelf")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView>, ATErrorResult>> DeleteMessageForSelfAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.DeleteMessageForSelfInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.DeletedMessageView>, ATErrorResult>> DeleteMessageForSelfAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.DeleteMessageForSelfInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -56,7 +56,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.convo.getConvo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoOutput>, ATErrorResult>> GetConvoAsync ([FromQuery] string convoId, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoOutput>, ATErrorResult>> GetConvoAsync ([FromQuery] string convoId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get whether the requester and the other members can chat. If an existing convo is found for these members, it is returned.
@@ -65,7 +65,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoAvailabilityOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.convo.getConvoAvailability")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoAvailabilityOutput>, ATErrorResult>> GetConvoAvailabilityAsync ([FromQuery] List<FishyFlip.Models.ATDid> members, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoAvailabilityOutput>, ATErrorResult>> GetConvoAvailabilityAsync ([FromQuery] List<FishyFlip.Models.ATDid> members, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -74,7 +74,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoForMembersOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.convo.getConvoForMembers")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoForMembersOutput>, ATErrorResult>> GetConvoForMembersAsync ([FromQuery] List<FishyFlip.Models.ATDid> members, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.GetConvoForMembersOutput>, ATErrorResult>> GetConvoForMembersAsync ([FromQuery] List<FishyFlip.Models.ATDid> members, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -83,7 +83,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.GetLogOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.convo.getLog")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.GetLogOutput>, ATErrorResult>> GetLogAsync ([FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.GetLogOutput>, ATErrorResult>> GetLogAsync ([FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -94,7 +94,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.GetMessagesOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.convo.getMessages")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.GetMessagesOutput>, ATErrorResult>> GetMessagesAsync ([FromQuery] string convoId, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.GetMessagesOutput>, ATErrorResult>> GetMessagesAsync ([FromQuery] string convoId, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -103,7 +103,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.leaveConvo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput>, ATErrorResult>> LeaveConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoOutput>, ATErrorResult>> LeaveConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.LeaveConvoInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -115,7 +115,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.ListConvosOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.convo.listConvos")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.ListConvosOutput>, ATErrorResult>> ListConvosAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? readState = default, [FromQuery] string? status = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.ListConvosOutput>, ATErrorResult>> ListConvosAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? readState = default, [FromQuery] string? status = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -124,7 +124,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.muteConvo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput>, ATErrorResult>> MuteConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoOutput>, ATErrorResult>> MuteConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.MuteConvoInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Removes an emoji reaction from a message. Requires authentication. It is idempotent, so multiple calls from the same user with the same emoji result in that reaction not being present, even if it already wasn't.
@@ -138,7 +138,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.RemoveReactionOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.removeReaction")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.RemoveReactionOutput>, ATErrorResult>> RemoveReactionAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.RemoveReactionInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.RemoveReactionOutput>, ATErrorResult>> RemoveReactionAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.RemoveReactionInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -148,7 +148,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.sendMessage")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView>, ATErrorResult>> SendMessageAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.MessageView>, ATErrorResult>> SendMessageAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -157,7 +157,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.sendMessageBatch")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput>, ATErrorResult>> SendMessageBatchAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchOutput>, ATErrorResult>> SendMessageBatchAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.SendMessageBatchInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -166,7 +166,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.unmuteConvo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput>, ATErrorResult>> UnmuteConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoOutput>, ATErrorResult>> UnmuteConvoAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.UnmuteConvoInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -175,7 +175,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateAllReadOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.updateAllRead")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateAllReadOutput>, ATErrorResult>> UpdateAllReadAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateAllReadInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateAllReadOutput>, ATErrorResult>> UpdateAllReadAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateAllReadInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// 
@@ -185,7 +185,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Convo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput"/></returns>
         [HttpPost("/xrpc/chat.bsky.convo.updateRead")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput>, ATErrorResult>> UpdateReadAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadOutput>, ATErrorResult>> UpdateReadAsync ([FromBody] FishyFlip.Lexicon.Chat.Bsky.Convo.UpdateReadInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Chat/Bsky/Moderation/ModerationController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Chat/Bsky/Moderation/ModerationController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Moderation.GetActorMetadataOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.moderation.getActorMetadata")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetActorMetadataOutput>, ATErrorResult>> GetActorMetadataAsync ([FromQuery] FishyFlip.Models.ATDid actor, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetActorMetadataOutput>, ATErrorResult>> GetActorMetadataAsync ([FromQuery] FishyFlip.Models.ATDid actor, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -34,7 +34,7 @@ namespace FishyFlip.Xrpc.Lexicon.Chat.Bsky.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Chat.Bsky.Moderation.GetMessageContextOutput"/></returns>
         [HttpGet("/xrpc/chat.bsky.moderation.getMessageContext")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetMessageContextOutput>, ATErrorResult>> GetMessageContextAsync ([FromQuery] string messageId, [FromQuery] string? convoId = default, [FromQuery] int? before = 5, [FromQuery] int? after = 5, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Chat.Bsky.Moderation.GetMessageContextOutput>, ATErrorResult>> GetMessageContextAsync ([FromQuery] string messageId, [FromQuery] string? convoId = default, [FromQuery] int? before = 5, [FromQuery] int? after = 5, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Admin/AdminController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Admin/AdminController.g.cs
@@ -61,7 +61,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Admin
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.AccountView"/></returns>
         [HttpGet("/xrpc/com.atproto.admin.getAccountInfo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Admin.AccountView>, ATErrorResult>> GetAccountInfoAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Admin.AccountView>, ATErrorResult>> GetAccountInfoAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get details about some accounts.
@@ -70,7 +70,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Admin
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.GetAccountInfosOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.admin.getAccountInfos")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Admin.GetAccountInfosOutput>, ATErrorResult>> GetAccountInfosAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Admin.GetAccountInfosOutput>, ATErrorResult>> GetAccountInfosAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get an admin view of invite codes.
@@ -81,7 +81,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Admin
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.GetInviteCodesOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.admin.getInviteCodes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Admin.GetInviteCodesOutput>, ATErrorResult>> GetInviteCodesAsync ([FromQuery] string? sort = default, [FromQuery] int? limit = 100, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Admin.GetInviteCodesOutput>, ATErrorResult>> GetInviteCodesAsync ([FromQuery] string? sort = default, [FromQuery] int? limit = 100, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the service-specific admin status of a subject (account, record, or blob).
@@ -92,7 +92,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Admin
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.GetSubjectStatusOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.admin.getSubjectStatus")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Admin.GetSubjectStatusOutput>, ATErrorResult>> GetSubjectStatusAsync ([FromQuery] FishyFlip.Models.ATDid? did = default, [FromQuery] FishyFlip.Models.ATUri? uri = default, [FromQuery] string? blob = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Admin.GetSubjectStatusOutput>, ATErrorResult>> GetSubjectStatusAsync ([FromQuery] FishyFlip.Models.ATDid? did = default, [FromQuery] FishyFlip.Models.ATUri? uri = default, [FromQuery] string? blob = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get list of accounts that matches your search query.
@@ -103,7 +103,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Admin
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.SearchAccountsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.admin.searchAccounts")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Admin.SearchAccountsOutput>, ATErrorResult>> SearchAccountsAsync ([FromQuery] string? email = default, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Admin.SearchAccountsOutput>, ATErrorResult>> SearchAccountsAsync ([FromQuery] string? email = default, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Send email to a user's account email address.
@@ -116,7 +116,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Admin
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.admin.sendEmail")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput>, ATErrorResult>> SendEmailAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailOutput>, ATErrorResult>> SendEmailAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Admin.SendEmailInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Administrative action to update an account's email.
@@ -172,7 +172,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Admin
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.admin.updateSubjectStatus")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput>, ATErrorResult>> UpdateSubjectStatusAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusOutput>, ATErrorResult>> UpdateSubjectStatusAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Admin.UpdateSubjectStatusInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Identity/IdentityController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Identity/IdentityController.g.cs
@@ -21,7 +21,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Identity
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Identity.GetRecommendedDidCredentialsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.identity.getRecommendedDidCredentials")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Identity.GetRecommendedDidCredentialsOutput>, ATErrorResult>> GetRecommendedDidCredentialsAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Identity.GetRecommendedDidCredentialsOutput>, ATErrorResult>> GetRecommendedDidCredentialsAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Request that the server re-resolve an identity (DID and handle). The server may ignore this request, or require authentication, depending on the role, implementation, and policy of the server.
@@ -34,7 +34,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Identity
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Identity.IdentityInfo"/></returns>
         [HttpPost("/xrpc/com.atproto.identity.refreshIdentity")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Identity.IdentityInfo>, ATErrorResult>> RefreshIdentityAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Identity.RefreshIdentityInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Identity.IdentityInfo>, ATErrorResult>> RefreshIdentityAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Identity.RefreshIdentityInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Request an email with a code to in order to request a signed PLC operation. Requires Auth.
@@ -54,7 +54,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Identity
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Identity.ResolveDidOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.identity.resolveDid")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveDidOutput>, ATErrorResult>> ResolveDidAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveDidOutput>, ATErrorResult>> ResolveDidAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves an atproto handle (hostname) to a DID. Does not necessarily bi-directionally verify against the the DID document.
@@ -65,7 +65,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Identity
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Identity.ResolveHandleOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.identity.resolveHandle")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveHandleOutput>, ATErrorResult>> ResolveHandleAsync ([FromQuery] FishyFlip.Models.ATHandle handle, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveHandleOutput>, ATErrorResult>> ResolveHandleAsync ([FromQuery] FishyFlip.Models.ATHandle handle, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves an identity (DID or Handle) to a full identity (DID document and verified handle).
@@ -78,7 +78,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Identity
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Identity.IdentityInfo"/></returns>
         [HttpGet("/xrpc/com.atproto.identity.resolveIdentity")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Identity.IdentityInfo>, ATErrorResult>> ResolveIdentityAsync ([FromQuery] FishyFlip.Models.ATIdentifier identifier, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Identity.IdentityInfo>, ATErrorResult>> ResolveIdentityAsync ([FromQuery] FishyFlip.Models.ATIdentifier identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Signs a PLC operation to update some value(s) in the requesting DID's document.
@@ -91,7 +91,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Identity
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.identity.signPlcOperation")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput>, ATErrorResult>> SignPlcOperationAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationOutput>, ATErrorResult>> SignPlcOperationAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Identity.SignPlcOperationInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Validates a PLC operation to ensure that it doesn't violate a service's constraints or get the identity into a bad state, then submits it to the PLC registry

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Label/LabelController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Label/LabelController.g.cs
@@ -25,7 +25,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Label
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Label.QueryLabelsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.label.queryLabels")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Label.QueryLabelsOutput>, ATErrorResult>> QueryLabelsAsync ([FromQuery] List<string> uriPatterns, [FromQuery] List<FishyFlip.Models.ATDid>? sources = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Label.QueryLabelsOutput>, ATErrorResult>> QueryLabelsAsync ([FromQuery] List<string> uriPatterns, [FromQuery] List<FishyFlip.Models.ATDid>? sources = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Moderation/ModerationController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Moderation/ModerationController.g.cs
@@ -37,7 +37,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.moderation.createReport")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput>, ATErrorResult>> CreateReportAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportOutput>, ATErrorResult>> CreateReportAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Moderation.CreateReportInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Repo/RepoController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Repo/RepoController.g.cs
@@ -27,7 +27,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.repo.applyWrites")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput>, ATErrorResult>> ApplyWritesAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesOutput>, ATErrorResult>> ApplyWritesAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.ApplyWritesInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create a single new repository record. Requires auth, implemented by PDS.
@@ -43,7 +43,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.repo.createRecord")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput>, ATErrorResult>> CreateRecordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordOutput>, ATErrorResult>> CreateRecordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.CreateRecordInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Delete a repository record, or ensure it doesn't exist. Requires auth, implemented by PDS.
@@ -58,7 +58,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.repo.deleteRecord")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput>, ATErrorResult>> DeleteRecordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordOutput>, ATErrorResult>> DeleteRecordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.DeleteRecordInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get information about an account and repository, including the list of collections. Does not require auth.
@@ -67,7 +67,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.DescribeRepoOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.repo.describeRepo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.DescribeRepoOutput>, ATErrorResult>> DescribeRepoAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.DescribeRepoOutput>, ATErrorResult>> DescribeRepoAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a single record from a repository. Does not require auth.
@@ -81,7 +81,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.GetRecordOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.repo.getRecord")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.GetRecordOutput>, ATErrorResult>> GetRecordAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, [FromQuery] string collection, [FromQuery] string rkey, [FromQuery] string? cid = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.GetRecordOutput>, ATErrorResult>> GetRecordAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, [FromQuery] string collection, [FromQuery] string rkey, [FromQuery] string? cid = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Import a repo in the form of a CAR file. Requires Content-Length HTTP header to be set.
@@ -100,7 +100,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.ListMissingBlobsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.repo.listMissingBlobs")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.ListMissingBlobsOutput>, ATErrorResult>> ListMissingBlobsAsync ([FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.ListMissingBlobsOutput>, ATErrorResult>> ListMissingBlobsAsync ([FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// List a range of records in a repository, matching a specific collection. Does not require auth.
@@ -113,7 +113,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.ListRecordsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.repo.listRecords")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.ListRecordsOutput>, ATErrorResult>> ListRecordsAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, [FromQuery] string collection, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] bool? reverse = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.ListRecordsOutput>, ATErrorResult>> ListRecordsAsync ([FromQuery] FishyFlip.Models.ATIdentifier repo, [FromQuery] string collection, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] bool? reverse = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write a repository record, creating or updating it as needed. Requires auth, implemented by PDS.
@@ -130,7 +130,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.repo.putRecord")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput>, ATErrorResult>> PutRecordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordOutput>, ATErrorResult>> PutRecordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Repo.PutRecordInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Upload a new blob, to be referenced from a repository record. The blob will be deleted if it is not referenced within a time window (eg, minutes). Blob restrictions (mimetype, size, etc) are enforced when the reference is created. Requires auth, implemented by PDS.
@@ -139,7 +139,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Repo
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.repo.uploadBlob")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput>, ATErrorResult>> UploadBlobAsync ([FromBody] StreamContent content, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Repo.UploadBlobOutput>, ATErrorResult>> UploadBlobAsync ([FromBody] StreamContent content, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Server/ServerController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Server/ServerController.g.cs
@@ -29,7 +29,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.CheckAccountStatusOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.server.checkAccountStatus")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.CheckAccountStatusOutput>, ATErrorResult>> CheckAccountStatusAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.CheckAccountStatusOutput>, ATErrorResult>> CheckAccountStatusAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Confirm an email using a token from com.atproto.server.requestEmailConfirmation.
@@ -69,7 +69,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.server.createAccount")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput>, ATErrorResult>> CreateAccountAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountOutput>, ATErrorResult>> CreateAccountAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateAccountInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create an App Password.
@@ -81,7 +81,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.AppPassword"/></returns>
         [HttpPost("/xrpc/com.atproto.server.createAppPassword")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.AppPassword>, ATErrorResult>> CreateAppPasswordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateAppPasswordInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.AppPassword>, ATErrorResult>> CreateAppPasswordAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateAppPasswordInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create an invite code.
@@ -91,7 +91,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.server.createInviteCode")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput>, ATErrorResult>> CreateInviteCodeAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeOutput>, ATErrorResult>> CreateInviteCodeAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodeInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create invite codes.
@@ -102,7 +102,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.server.createInviteCodes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput>, ATErrorResult>> CreateInviteCodesAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesOutput>, ATErrorResult>> CreateInviteCodesAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateInviteCodesInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create an authentication session.
@@ -117,7 +117,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.server.createSession")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput>, ATErrorResult>> CreateSessionAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionOutput>, ATErrorResult>> CreateSessionAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.CreateSessionInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Deactivates a currently active account. Stops serving of repo, and future writes to repo until reactivated. Used to finalize account migration with the old host after the account has been activated on the new host.
@@ -156,7 +156,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.DescribeServerOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.server.describeServer")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.DescribeServerOutput>, ATErrorResult>> DescribeServerAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.DescribeServerOutput>, ATErrorResult>> DescribeServerAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get all invite codes for the current account. Requires auth.
@@ -168,7 +168,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.GetAccountInviteCodesOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.server.getAccountInviteCodes")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.GetAccountInviteCodesOutput>, ATErrorResult>> GetAccountInviteCodesAsync ([FromQuery] bool? includeUsed = default, [FromQuery] bool? createAvailable = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.GetAccountInviteCodesOutput>, ATErrorResult>> GetAccountInviteCodesAsync ([FromQuery] bool? includeUsed = default, [FromQuery] bool? createAvailable = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a signed token on behalf of the requesting DID for the requested service.
@@ -181,7 +181,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.GetServiceAuthOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.server.getServiceAuth")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.GetServiceAuthOutput>, ATErrorResult>> GetServiceAuthAsync ([FromQuery] FishyFlip.Models.ATDid aud, [FromQuery] int? exp = 0, [FromQuery] string? lxm = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.GetServiceAuthOutput>, ATErrorResult>> GetServiceAuthAsync ([FromQuery] FishyFlip.Models.ATDid aud, [FromQuery] int? exp = 0, [FromQuery] string? lxm = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get information about the current auth session. Requires auth.
@@ -189,7 +189,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.GetSessionOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.server.getSession")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.GetSessionOutput>, ATErrorResult>> GetSessionAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.GetSessionOutput>, ATErrorResult>> GetSessionAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// List all App Passwords.
@@ -199,7 +199,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.ListAppPasswordsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.server.listAppPasswords")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.ListAppPasswordsOutput>, ATErrorResult>> ListAppPasswordsAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.ListAppPasswordsOutput>, ATErrorResult>> ListAppPasswordsAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Refresh an authentication session. Requires auth using the 'refreshJwt' (not the 'accessJwt').
@@ -209,7 +209,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.server.refreshSession")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput>, ATErrorResult>> RefreshSessionAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.RefreshSessionOutput>, ATErrorResult>> RefreshSessionAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Initiate a user account deletion via email.
@@ -233,7 +233,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.server.requestEmailUpdate")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput>, ATErrorResult>> RequestEmailUpdateAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.RequestEmailUpdateOutput>, ATErrorResult>> RequestEmailUpdateAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Initiate a user account password reset via email.
@@ -251,7 +251,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.server.reserveSigningKey")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput>, ATErrorResult>> ReserveSigningKeyAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyOutput>, ATErrorResult>> ReserveSigningKeyAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Server.ReserveSigningKeyInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Reset a user account password using a token.

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Sync/SyncController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Sync/SyncController.g.cs
@@ -56,7 +56,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Sync
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.GetHostStatusOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.sync.getHostStatus")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Sync.GetHostStatusOutput>, ATErrorResult>> GetHostStatusAsync ([FromQuery] string hostname, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Sync.GetHostStatusOutput>, ATErrorResult>> GetHostStatusAsync ([FromQuery] string hostname, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the current commit CID & revision of the specified repo. Does not require auth.
@@ -70,7 +70,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Sync
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.GetLatestCommitOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.sync.getLatestCommit")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Sync.GetLatestCommitOutput>, ATErrorResult>> GetLatestCommitAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Sync.GetLatestCommitOutput>, ATErrorResult>> GetLatestCommitAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get data blocks needed to prove the existence or non-existence of record in the current version of repo. Does not require auth.
@@ -113,7 +113,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Sync
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.GetRepoStatusOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.sync.getRepoStatus")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Sync.GetRepoStatusOutput>, ATErrorResult>> GetRepoStatusAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Sync.GetRepoStatusOutput>, ATErrorResult>> GetRepoStatusAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// List blob CIDs for an account, since some repo revision. Does not require auth; implemented by PDS.
@@ -130,7 +130,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Sync
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.ListBlobsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.sync.listBlobs")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Sync.ListBlobsOutput>, ATErrorResult>> ListBlobsAsync ([FromQuery] FishyFlip.Models.ATDid did, [FromQuery] string? since = default, [FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Sync.ListBlobsOutput>, ATErrorResult>> ListBlobsAsync ([FromQuery] FishyFlip.Models.ATDid did, [FromQuery] string? since = default, [FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates upstream hosts (eg, PDS or relay instances) that this service consumes from. Implemented by relays.
@@ -140,7 +140,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Sync
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.ListHostsOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.sync.listHosts")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Sync.ListHostsOutput>, ATErrorResult>> ListHostsAsync ([FromQuery] int? limit = 200, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Sync.ListHostsOutput>, ATErrorResult>> ListHostsAsync ([FromQuery] int? limit = 200, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates all the DID, rev, and commit CID for all repos hosted by this service. Does not require auth; implemented by PDS and Relay.
@@ -150,7 +150,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Sync
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.ListReposOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.sync.listRepos")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposOutput>, ATErrorResult>> ListReposAsync ([FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposOutput>, ATErrorResult>> ListReposAsync ([FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates all the DIDs which have records with the given collection NSID.
@@ -161,7 +161,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Sync
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Sync.ListReposByCollectionOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.sync.listReposByCollection")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposByCollectionOutput>, ATErrorResult>> ListReposByCollectionAsync ([FromQuery] string collection, [FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposByCollectionOutput>, ATErrorResult>> ListReposByCollectionAsync ([FromQuery] string collection, [FromQuery] int? limit = 500, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Request a service to persistently crawl hosted repos. Expected use is new PDS instances declaring their existence to Relays. Does not require auth.

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Temp/TempController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Atproto/Temp/TempController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Temp
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput"/></returns>
         [HttpPost("/xrpc/com.atproto.temp.addReservedHandle")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput>, ATErrorResult>> AddReservedHandleAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleOutput>, ATErrorResult>> AddReservedHandleAsync ([FromBody] FishyFlip.Lexicon.Com.Atproto.Temp.AddReservedHandleInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Check accounts location in signup queue.
@@ -30,7 +30,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Atproto.Temp
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Atproto.Temp.CheckSignupQueueOutput"/></returns>
         [HttpGet("/xrpc/com.atproto.temp.checkSignupQueue")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Atproto.Temp.CheckSignupQueueOutput>, ATErrorResult>> CheckSignupQueueAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Atproto.Temp.CheckSignupQueueOutput>, ATErrorResult>> CheckSignupQueueAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Request a verification code to be sent to the supplied phone number

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Shinolabs/Pinksea/PinkseaController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Shinolabs/Pinksea/PinkseaController.g.cs
@@ -24,7 +24,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorFeedOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getAuthorFeed")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorFeedOutput>, ATErrorResult>> GetAuthorFeedAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorFeedOutput>, ATErrorResult>> GetAuthorFeedAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the replies for an author.
@@ -35,7 +35,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorRepliesOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getAuthorReplies")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorRepliesOutput>, ATErrorResult>> GetAuthorRepliesAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorRepliesOutput>, ATErrorResult>> GetAuthorRepliesAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the handle for a DID.
@@ -44,7 +44,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetHandleFromDidOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getHandleFromDid")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetHandleFromDidOutput>, ATErrorResult>> GetHandleFromDidAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetHandleFromDidOutput>, ATErrorResult>> GetHandleFromDidAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the identity of the authenticated user.
@@ -52,7 +52,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetIdentityOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getIdentity")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetIdentityOutput>, ATErrorResult>> GetIdentityAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetIdentityOutput>, ATErrorResult>> GetIdentityAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the data about an oekaki post, with its children
@@ -62,7 +62,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetOekakiOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getOekaki")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetOekakiOutput>, ATErrorResult>> GetOekakiAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] string rkey, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetOekakiOutput>, ATErrorResult>> GetOekakiAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] string rkey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the parent for a reply.
@@ -72,7 +72,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetParentForReplyOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getParentForReply")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetParentForReplyOutput>, ATErrorResult>> GetParentForReplyAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] string rkey, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetParentForReplyOutput>, ATErrorResult>> GetParentForReplyAsync ([FromQuery] FishyFlip.Models.ATIdentifier did, [FromQuery] string rkey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the most recent posts on the timeline, in reverse chronological order.
@@ -82,7 +82,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetRecentOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getRecent")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetRecentOutput>, ATErrorResult>> GetRecentAsync ([FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetRecentOutput>, ATErrorResult>> GetRecentAsync ([FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the feed for a given tag.
@@ -93,7 +93,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Shinolabs.Pinksea
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetTagFeedOutput"/></returns>
         [HttpGet("/xrpc/com.shinolabs.pinksea.getTagFeed")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetTagFeedOutput>, ATErrorResult>> GetTagFeedAsync ([FromQuery] string tag, [FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetTagFeedOutput>, ATErrorResult>> GetTagFeedAsync ([FromQuery] string tag, [FromQuery] DateTime? since = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Com/Whtwnd/Blog/BlogController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Com/Whtwnd/Blog/BlogController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Whtwnd.Blog
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Whtwnd.Blog.GetAuthorPostsOutput"/></returns>
         [HttpGet("/xrpc/com.whtwnd.blog.getAuthorPosts")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetAuthorPostsOutput>, ATErrorResult>> GetAuthorPostsAsync ([FromQuery] FishyFlip.Models.ATDid author, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetAuthorPostsOutput>, ATErrorResult>> GetAuthorPostsAsync ([FromQuery] FishyFlip.Models.ATDid author, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get AT URI by blog author and entry name. If there are multiple blog entries associated with the name, return the latest one.
@@ -34,7 +34,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Whtwnd.Blog
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Whtwnd.Blog.GetEntryMetadataByNameOutput"/></returns>
         [HttpGet("/xrpc/com.whtwnd.blog.getEntryMetadataByName")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetEntryMetadataByNameOutput>, ATErrorResult>> GetEntryMetadataByNameAsync ([FromQuery] FishyFlip.Models.ATIdentifier author, [FromQuery] string entryTitle, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetEntryMetadataByNameOutput>, ATErrorResult>> GetEntryMetadataByNameAsync ([FromQuery] FishyFlip.Models.ATIdentifier author, [FromQuery] string entryTitle, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get comments associated to designated post.
@@ -43,7 +43,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Whtwnd.Blog
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Whtwnd.Blog.GetMentionsByEntryOutput"/></returns>
         [HttpGet("/xrpc/com.whtwnd.blog.getMentionsByEntry")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetMentionsByEntryOutput>, ATErrorResult>> GetMentionsByEntryAsync ([FromQuery] FishyFlip.Models.ATUri postUri, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetMentionsByEntryOutput>, ATErrorResult>> GetMentionsByEntryAsync ([FromQuery] FishyFlip.Models.ATUri postUri, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Notify AppView of existence of new entry and request indexing
@@ -52,7 +52,7 @@ namespace FishyFlip.Xrpc.Lexicon.Com.Whtwnd.Blog
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput"/></returns>
         [HttpPost("/xrpc/com.whtwnd.blog.notifyOfNewEntry")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput>, ATErrorResult>> NotifyOfNewEntryAsync ([FromBody] FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryOutput>, ATErrorResult>> NotifyOfNewEntryAsync ([FromBody] FishyFlip.Lexicon.Com.Whtwnd.Blog.NotifyOfNewEntryInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Community/Lexicon/Bookmarks/BookmarksController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Community/Lexicon/Bookmarks/BookmarksController.g.cs
@@ -24,7 +24,7 @@ namespace FishyFlip.Xrpc.Lexicon.Community.Lexicon.Bookmarks
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Community.Lexicon.Bookmarks.GetActorBookmarksOutput"/></returns>
         [HttpGet("/xrpc/community.lexicon.bookmarks.getActorBookmarks")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Community.Lexicon.Bookmarks.GetActorBookmarksOutput>, ATErrorResult>> GetActorBookmarksAsync ([FromQuery] List<string>? tags = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Community.Lexicon.Bookmarks.GetActorBookmarksOutput>, ATErrorResult>> GetActorBookmarksAsync ([FromQuery] List<string>? tags = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Fm/Teal/Alpha/Actor/ActorController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Fm/Teal/Alpha/Actor/ActorController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Fm.Teal.Alpha.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfileOutput"/></returns>
         [HttpGet("/xrpc/fm.teal.alpha.actor.getProfile")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfileOutput>, ATErrorResult>> GetProfileAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfileOutput>, ATErrorResult>> GetProfileAsync ([FromQuery] FishyFlip.Models.ATIdentifier actor, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -31,7 +31,7 @@ namespace FishyFlip.Xrpc.Lexicon.Fm.Teal.Alpha.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfilesOutput"/></returns>
         [HttpGet("/xrpc/fm.teal.alpha.actor.getProfiles")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfilesOutput>, ATErrorResult>> GetProfilesAsync ([FromQuery] List<FishyFlip.Models.ATIdentifier> actors, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfilesOutput>, ATErrorResult>> GetProfilesAsync ([FromQuery] List<FishyFlip.Models.ATIdentifier> actors, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -42,7 +42,7 @@ namespace FishyFlip.Xrpc.Lexicon.Fm.Teal.Alpha.Actor
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.SearchActorsOutput"/></returns>
         [HttpGet("/xrpc/fm.teal.alpha.actor.searchActors")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.SearchActorsOutput>, ATErrorResult>> SearchActorsAsync ([FromQuery] string q, [FromQuery] int? limit = 0, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.SearchActorsOutput>, ATErrorResult>> SearchActorsAsync ([FromQuery] string q, [FromQuery] int? limit = 0, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Fm/Teal/Alpha/Feed/FeedController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Fm/Teal/Alpha/Feed/FeedController.g.cs
@@ -24,7 +24,7 @@ namespace FishyFlip.Xrpc.Lexicon.Fm.Teal.Alpha.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetActorFeedOutput"/></returns>
         [HttpGet("/xrpc/fm.teal.alpha.feed.getActorFeed")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetActorFeedOutput>, ATErrorResult>> GetActorFeedAsync ([FromQuery] FishyFlip.Models.ATIdentifier authorDID, [FromQuery] string? cursor = default, [FromQuery] int? limit = 0, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetActorFeedOutput>, ATErrorResult>> GetActorFeedAsync ([FromQuery] FishyFlip.Models.ATIdentifier authorDID, [FromQuery] string? cursor = default, [FromQuery] int? limit = 0, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// 
@@ -34,7 +34,7 @@ namespace FishyFlip.Xrpc.Lexicon.Fm.Teal.Alpha.Feed
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetPlayOutput"/></returns>
         [HttpGet("/xrpc/fm.teal.alpha.feed.getPlay")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetPlayOutput>, ATErrorResult>> GetPlayAsync ([FromQuery] FishyFlip.Models.ATIdentifier authorDID, [FromQuery] string rkey, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetPlayOutput>, ATErrorResult>> GetPlayAsync ([FromQuery] FishyFlip.Models.ATIdentifier authorDID, [FromQuery] string rkey, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Communication/CommunicationController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Communication/CommunicationController.g.cs
@@ -28,7 +28,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Communication
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView"/></returns>
         [HttpPost("/xrpc/tools.ozone.communication.createTemplate")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView>, ATErrorResult>> CreateTemplateAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Communication.CreateTemplateInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView>, ATErrorResult>> CreateTemplateAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Communication.CreateTemplateInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Delete a communication template.
@@ -45,7 +45,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Communication
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Communication.ListTemplatesOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.communication.listTemplates")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Communication.ListTemplatesOutput>, ATErrorResult>> ListTemplatesAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Communication.ListTemplatesOutput>, ATErrorResult>> ListTemplatesAsync (CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Administrative action to update an existing communication template. Allows passing partial fields to patch specific fields only.
@@ -62,7 +62,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Communication
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView"/></returns>
         [HttpPost("/xrpc/tools.ozone.communication.updateTemplate")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView>, ATErrorResult>> UpdateTemplateAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Communication.UpdateTemplateInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Communication.TemplateView>, ATErrorResult>> UpdateTemplateAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Communication.UpdateTemplateInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Hosting/HostingController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Hosting/HostingController.g.cs
@@ -25,7 +25,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Hosting
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Hosting.GetAccountHistoryOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.hosting.getAccountHistory")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Hosting.GetAccountHistoryOutput>, ATErrorResult>> GetAccountHistoryAsync ([FromQuery] FishyFlip.Models.ATDid did, [FromQuery] List<string>? events = default, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Hosting.GetAccountHistoryOutput>, ATErrorResult>> GetAccountHistoryAsync ([FromQuery] FishyFlip.Models.ATDid did, [FromQuery] List<string>? events = default, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Moderation/ModerationController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Moderation/ModerationController.g.cs
@@ -52,7 +52,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView"/></returns>
         [HttpPost("/xrpc/tools.ozone.moderation.emitEvent")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView>, ATErrorResult>> EmitEventAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Moderation.EmitEventInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventView>, ATErrorResult>> EmitEventAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Moderation.EmitEventInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get details about a moderation event.
@@ -61,7 +61,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventViewDetail"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.getEvent")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventViewDetail>, ATErrorResult>> GetEventAsync ([FromQuery] int id, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.ModEventViewDetail>, ATErrorResult>> GetEventAsync ([FromQuery] int id, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get details about a record.
@@ -73,7 +73,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.getRecord")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail>, ATErrorResult>> GetRecordAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.RecordViewDetail>, ATErrorResult>> GetRecordAsync ([FromQuery] FishyFlip.Models.ATUri uri, [FromQuery] string? cid = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get details about some records.
@@ -82,7 +82,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.GetRecordsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.getRecords")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetRecordsOutput>, ATErrorResult>> GetRecordsAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetRecordsOutput>, ATErrorResult>> GetRecordsAsync ([FromQuery] List<FishyFlip.Models.ATUri> uris, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get details about a repository.
@@ -93,7 +93,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.getRepo")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail>, ATErrorResult>> GetRepoAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.RepoViewDetail>, ATErrorResult>> GetRepoAsync ([FromQuery] FishyFlip.Models.ATDid did, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get reporter stats for a list of users.
@@ -102,7 +102,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReporterStatsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.getReporterStats")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReporterStatsOutput>, ATErrorResult>> GetReporterStatsAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReporterStatsOutput>, ATErrorResult>> GetReporterStatsAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get details about some repositories.
@@ -111,7 +111,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReposOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.getRepos")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReposOutput>, ATErrorResult>> GetReposAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetReposOutput>, ATErrorResult>> GetReposAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get details about subjects.
@@ -120,7 +120,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.GetSubjectsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.getSubjects")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetSubjectsOutput>, ATErrorResult>> GetSubjectsAsync ([FromQuery] List<string> subjects, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.GetSubjectsOutput>, ATErrorResult>> GetSubjectsAsync ([FromQuery] List<string> subjects, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// List moderation events related to a subject.
@@ -147,7 +147,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryEventsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.queryEvents")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryEventsOutput>, ATErrorResult>> QueryEventsAsync ([FromQuery] List<string>? types = default, [FromQuery] FishyFlip.Models.ATDid? createdBy = default, [FromQuery] string? sortDirection = default, [FromQuery] DateTime? createdAfter = default, [FromQuery] DateTime? createdBefore = default, [FromQuery] string? subject = default, [FromQuery] List<string>? collections = default, [FromQuery] string? subjectType = default, [FromQuery] bool? includeAllUserRecords = default, [FromQuery] int? limit = 50, [FromQuery] bool? hasComment = default, [FromQuery] string? comment = default, [FromQuery] List<string>? addedLabels = default, [FromQuery] List<string>? removedLabels = default, [FromQuery] List<string>? addedTags = default, [FromQuery] List<string>? removedTags = default, [FromQuery] List<string>? reportTypes = default, [FromQuery] List<string>? policies = default, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryEventsOutput>, ATErrorResult>> QueryEventsAsync ([FromQuery] List<string>? types = default, [FromQuery] FishyFlip.Models.ATDid? createdBy = default, [FromQuery] string? sortDirection = default, [FromQuery] DateTime? createdAfter = default, [FromQuery] DateTime? createdBefore = default, [FromQuery] string? subject = default, [FromQuery] List<string>? collections = default, [FromQuery] string? subjectType = default, [FromQuery] bool? includeAllUserRecords = default, [FromQuery] int? limit = 50, [FromQuery] bool? hasComment = default, [FromQuery] string? comment = default, [FromQuery] List<string>? addedLabels = default, [FromQuery] List<string>? removedLabels = default, [FromQuery] List<string>? addedTags = default, [FromQuery] List<string>? removedTags = default, [FromQuery] List<string>? reportTypes = default, [FromQuery] List<string>? policies = default, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// View moderation statuses of subjects (record or repo).
@@ -189,7 +189,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryStatusesOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.queryStatuses")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryStatusesOutput>, ATErrorResult>> QueryStatusesAsync ([FromQuery] int? queueCount = 0, [FromQuery] int? queueIndex = 0, [FromQuery] string? queueSeed = default, [FromQuery] bool? includeAllUserRecords = default, [FromQuery] string? subject = default, [FromQuery] string? comment = default, [FromQuery] DateTime? reportedAfter = default, [FromQuery] DateTime? reportedBefore = default, [FromQuery] DateTime? reviewedAfter = default, [FromQuery] DateTime? hostingDeletedAfter = default, [FromQuery] DateTime? hostingDeletedBefore = default, [FromQuery] DateTime? hostingUpdatedAfter = default, [FromQuery] DateTime? hostingUpdatedBefore = default, [FromQuery] List<string>? hostingStatuses = default, [FromQuery] DateTime? reviewedBefore = default, [FromQuery] bool? includeMuted = default, [FromQuery] bool? onlyMuted = default, [FromQuery] string? reviewState = default, [FromQuery] List<string>? ignoreSubjects = default, [FromQuery] FishyFlip.Models.ATDid? lastReviewedBy = default, [FromQuery] string? sortField = default, [FromQuery] string? sortDirection = default, [FromQuery] bool? takendown = default, [FromQuery] bool? appealed = default, [FromQuery] int? limit = 50, [FromQuery] List<string>? tags = default, [FromQuery] List<string>? excludeTags = default, [FromQuery] string? cursor = default, [FromQuery] List<string>? collections = default, [FromQuery] string? subjectType = default, [FromQuery] int? minAccountSuspendCount = 0, [FromQuery] int? minReportedRecordsCount = 0, [FromQuery] int? minTakendownRecordsCount = 0, [FromQuery] int? minPriorityScore = 0, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.QueryStatusesOutput>, ATErrorResult>> QueryStatusesAsync ([FromQuery] int? queueCount = 0, [FromQuery] int? queueIndex = 0, [FromQuery] string? queueSeed = default, [FromQuery] bool? includeAllUserRecords = default, [FromQuery] string? subject = default, [FromQuery] string? comment = default, [FromQuery] DateTime? reportedAfter = default, [FromQuery] DateTime? reportedBefore = default, [FromQuery] DateTime? reviewedAfter = default, [FromQuery] DateTime? hostingDeletedAfter = default, [FromQuery] DateTime? hostingDeletedBefore = default, [FromQuery] DateTime? hostingUpdatedAfter = default, [FromQuery] DateTime? hostingUpdatedBefore = default, [FromQuery] List<string>? hostingStatuses = default, [FromQuery] DateTime? reviewedBefore = default, [FromQuery] bool? includeMuted = default, [FromQuery] bool? onlyMuted = default, [FromQuery] string? reviewState = default, [FromQuery] List<string>? ignoreSubjects = default, [FromQuery] FishyFlip.Models.ATDid? lastReviewedBy = default, [FromQuery] string? sortField = default, [FromQuery] string? sortDirection = default, [FromQuery] bool? takendown = default, [FromQuery] bool? appealed = default, [FromQuery] int? limit = 50, [FromQuery] List<string>? tags = default, [FromQuery] List<string>? excludeTags = default, [FromQuery] string? cursor = default, [FromQuery] List<string>? collections = default, [FromQuery] string? subjectType = default, [FromQuery] int? minAccountSuspendCount = 0, [FromQuery] int? minReportedRecordsCount = 0, [FromQuery] int? minTakendownRecordsCount = 0, [FromQuery] int? minPriorityScore = 0, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find repositories based on a search term.
@@ -200,7 +200,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Moderation
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Moderation.SearchReposOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.moderation.searchRepos")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Moderation.SearchReposOutput>, ATErrorResult>> SearchReposAsync ([FromQuery] string? q = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Moderation.SearchReposOutput>, ATErrorResult>> SearchReposAsync ([FromQuery] string? q = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Server/ServerController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Server/ServerController.g.cs
@@ -21,7 +21,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Server
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Server.GetConfigOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.server.getConfig")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Server.GetConfigOutput>, ATErrorResult>> GetConfigAsync (CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Server.GetConfigOutput>, ATErrorResult>> GetConfigAsync (CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Set/SetController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Set/SetController.g.cs
@@ -34,7 +34,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Set
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput"/></returns>
         [HttpPost("/xrpc/tools.ozone.set.deleteSet")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput>, ATErrorResult>> DeleteSetAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetOutput>, ATErrorResult>> DeleteSetAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Set.DeleteSetInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Delete values from a specific set. Attempting to delete values that are not in the set will not result in an error
@@ -59,7 +59,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Set
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Set.GetValuesOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.set.getValues")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Set.GetValuesOutput>, ATErrorResult>> GetValuesAsync ([FromQuery] string name, [FromQuery] int? limit = 100, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Set.GetValuesOutput>, ATErrorResult>> GetValuesAsync ([FromQuery] string name, [FromQuery] int? limit = 100, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Query available sets
@@ -72,7 +72,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Set
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Set.QuerySetsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.set.querySets")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Set.QuerySetsOutput>, ATErrorResult>> QuerySetsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? namePrefix = default, [FromQuery] string? sortBy = default, [FromQuery] string? sortDirection = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Set.QuerySetsOutput>, ATErrorResult>> QuerySetsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? namePrefix = default, [FromQuery] string? sortBy = default, [FromQuery] string? sortDirection = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Create or update set metadata
@@ -81,7 +81,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Set
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Set.SetView"/></returns>
         [HttpPost("/xrpc/tools.ozone.set.upsertSet")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Set.SetView>, ATErrorResult>> UpsertSetAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Set.UpsertSetInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Set.SetView>, ATErrorResult>> UpsertSetAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Set.UpsertSetInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Setting/SettingController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Setting/SettingController.g.cs
@@ -26,7 +26,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Setting
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Setting.ListOptionsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.setting.listOptions")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Setting.ListOptionsOutput>, ATErrorResult>> ListOptionsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? scope = default, [FromQuery] string? prefix = default, [FromQuery] List<string>? keys = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Setting.ListOptionsOutput>, ATErrorResult>> ListOptionsAsync ([FromQuery] int? limit = 50, [FromQuery] string? cursor = default, [FromQuery] string? scope = default, [FromQuery] string? prefix = default, [FromQuery] List<string>? keys = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Delete settings by key
@@ -36,7 +36,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Setting
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput"/></returns>
         [HttpPost("/xrpc/tools.ozone.setting.removeOptions")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput>, ATErrorResult>> RemoveOptionsAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsOutput>, ATErrorResult>> RemoveOptionsAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Setting.RemoveOptionsInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create or update setting option
@@ -49,7 +49,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Setting
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput"/></returns>
         [HttpPost("/xrpc/tools.ozone.setting.upsertOption")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput>, ATErrorResult>> UpsertOptionAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionOutput>, ATErrorResult>> UpsertOptionAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Setting.UpsertOptionInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Signature/SignatureController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Signature/SignatureController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Signature
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Signature.FindCorrelationOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.signature.findCorrelation")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Signature.FindCorrelationOutput>, ATErrorResult>> FindCorrelationAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Signature.FindCorrelationOutput>, ATErrorResult>> FindCorrelationAsync ([FromQuery] List<FishyFlip.Models.ATDid> dids, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get accounts that share some matching threat signatures with the root account.
@@ -33,7 +33,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Signature
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Signature.FindRelatedAccountsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.signature.findRelatedAccounts")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Signature.FindRelatedAccountsOutput>, ATErrorResult>> FindRelatedAccountsAsync ([FromQuery] FishyFlip.Models.ATDid did, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Signature.FindRelatedAccountsOutput>, ATErrorResult>> FindRelatedAccountsAsync ([FromQuery] FishyFlip.Models.ATDid did, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Search for accounts that match one or more threat signature values.
@@ -44,7 +44,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Signature
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Signature.SearchAccountsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.signature.searchAccounts")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Signature.SearchAccountsOutput>, ATErrorResult>> SearchAccountsAsync ([FromQuery] List<string> values, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Signature.SearchAccountsOutput>, ATErrorResult>> SearchAccountsAsync ([FromQuery] List<string> values, [FromQuery] string? cursor = default, [FromQuery] int? limit = 50, CancellationToken cancellationToken = default);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Team/TeamController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Team/TeamController.g.cs
@@ -25,7 +25,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Team
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Team.Member"/></returns>
         [HttpPost("/xrpc/tools.ozone.team.addMember")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Team.Member>, ATErrorResult>> AddMemberAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Team.AddMemberInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Team.Member>, ATErrorResult>> AddMemberAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Team.AddMemberInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// Delete a member from ozone team. Requires admin role.
@@ -50,7 +50,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Team
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Team.ListMembersOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.team.listMembers")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Team.ListMembersOutput>, ATErrorResult>> ListMembersAsync ([FromQuery] string? q = default, [FromQuery] bool? disabled = default, [FromQuery] List<string>? roles = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Team.ListMembersOutput>, ATErrorResult>> ListMembersAsync ([FromQuery] string? q = default, [FromQuery] bool? disabled = default, [FromQuery] List<string>? roles = default, [FromQuery] int? limit = 50, [FromQuery] string? cursor = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Update a member in the ozone service. Requires admin role.
@@ -63,7 +63,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Team
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Team.Member"/></returns>
         [HttpPost("/xrpc/tools.ozone.team.updateMember")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Team.Member>, ATErrorResult>> UpdateMemberAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Team.UpdateMemberInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Team.Member>, ATErrorResult>> UpdateMemberAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Team.UpdateMemberInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Verification/VerificationController.g.cs
+++ b/src/FishyFlip.Xrpc/Lexicon/Tools/Ozone/Verification/VerificationController.g.cs
@@ -22,7 +22,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Verification
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Verification.GrantVerificationsOutput"/></returns>
         [HttpPost("/xrpc/tools.ozone.verification.grantVerifications")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Verification.GrantVerificationsOutput>, ATErrorResult>> GrantVerificationsAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Verification.GrantVerificationsInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Verification.GrantVerificationsOutput>, ATErrorResult>> GrantVerificationsAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Verification.GrantVerificationsInput input, CancellationToken cancellationToken);
 
         /// <summary>
         /// List verifications
@@ -38,7 +38,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Verification
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Verification.ListVerificationsOutput"/></returns>
         [HttpGet("/xrpc/tools.ozone.verification.listVerifications")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Verification.ListVerificationsOutput>, ATErrorResult>> ListVerificationsAsync ([FromQuery] string? cursor = default, [FromQuery] int? limit = 50, [FromQuery] DateTime? createdAfter = default, [FromQuery] DateTime? createdBefore = default, [FromQuery] List<FishyFlip.Models.ATDid>? issuers = default, [FromQuery] List<FishyFlip.Models.ATDid>? subjects = default, [FromQuery] string? sortDirection = default, [FromQuery] bool? isRevoked = default, CancellationToken cancellationToken = default);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Verification.ListVerificationsOutput>, ATErrorResult>> ListVerificationsAsync ([FromQuery] string? cursor = default, [FromQuery] int? limit = 50, [FromQuery] DateTime? createdAfter = default, [FromQuery] DateTime? createdBefore = default, [FromQuery] List<FishyFlip.Models.ATDid>? issuers = default, [FromQuery] List<FishyFlip.Models.ATDid>? subjects = default, [FromQuery] string? sortDirection = default, [FromQuery] bool? isRevoked = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Revoke previously granted verifications in batches of up to 100.
@@ -48,7 +48,7 @@ namespace FishyFlip.Xrpc.Lexicon.Tools.Ozone.Verification
         /// <param name="cancellationToken"></param>
         /// <returns>Result of <see cref="FishyFlip.Lexicon.Tools.Ozone.Verification.RevokeVerificationsOutput"/></returns>
         [HttpPost("/xrpc/tools.ozone.verification.revokeVerifications")]
-        public abstract Task<Results<Ok<FishyFlip.Lexicon.Tools.Ozone.Verification.RevokeVerificationsOutput>, ATErrorResult>> RevokeVerificationsAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Verification.RevokeVerificationsInput input, CancellationToken cancellationToken);
+        public abstract Task<Results<ATResult<FishyFlip.Lexicon.Tools.Ozone.Verification.RevokeVerificationsOutput>, ATErrorResult>> RevokeVerificationsAsync ([FromBody] FishyFlip.Lexicon.Tools.Ozone.Verification.RevokeVerificationsInput input, CancellationToken cancellationToken);
     }
 }
 

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -1390,9 +1390,17 @@ public partial class AppCommands
             {
                 sb.Append($"        public abstract Task<Results<FileStreamHttpResult, ATErrorResult>> {methodName} (");
             }
+            else if (outputProperty == "byte[]")
+            {
+                sb.Append($"        public abstract Task<Results<Ok<byte[]>, ATErrorResult>> {methodName} (");
+            }
+            else if (outputProperty == "string")
+            {
+                sb.Append($"        public abstract Task<Results<Ok<string>, ATErrorResult>> {methodName} (");
+            }
             else
             {
-                sb.Append($"        public abstract Task<Results<Ok<{outputProperty}>, ATErrorResult>> {methodName} (");
+                sb.Append($"        public abstract Task<Results<ATResult<{outputProperty}>, ATErrorResult>> {methodName} (");
             }
             for (int i = 0; i < inputProperties.Count; i++)
             {
@@ -1487,9 +1495,17 @@ public partial class AppCommands
             {
                 sb.Append($"        public abstract Task<Results<FileStreamHttpResult, ATErrorResult>> {methodName} (");
             }
+            else if (outputProperty == "byte[]")
+            {
+                sb.Append($"        public abstract Task<Results<Ok<byte[]>, ATErrorResult>> {methodName} (");
+            }
+            else if (outputProperty == "string")
+            {
+                sb.Append($"        public abstract Task<Results<Ok<string>, ATErrorResult>> {methodName} (");
+            }
             else
             {
-                sb.Append($"        public abstract Task<Results<Ok<{outputProperty}>, ATErrorResult>> {methodName} (");
+                sb.Append($"        public abstract Task<Results<ATResult<{outputProperty}>, ATErrorResult>> {methodName} (");
             }
             for (int i = 0; i < inputProperties.Count; i++)
             {


### PR DESCRIPTION
This adds `ATResult` to FishyFlip.Xrpc, which takes an `ATObject` and will deserialize the data to JSON through the built in source generator, or whatever you want for custom ATObjects. The other non-ATObject types (byte[], string) remain the same.

Fixes #273 