### PR TITLE
Add third-party ATProto Service Proxy Support

### DIFF
--- a/src/FishyFlip/ATProtocolBuilder.cs
+++ b/src/FishyFlip/ATProtocolBuilder.cs
@@ -163,7 +163,8 @@ public class ATProtocolBuilder
 
     /// <summary>
     /// Adds a cache set of ATProxy values with their respective service labels.
-    /// The key should resolve to the NSID of the service, ex. com.whtwnd.blog.
+    /// The key should resolve to the group namespace of the endpoint, ex. com.whtwnd.blog.
+    /// or the subset of it, ex. com.whtwnd.
     /// The value should be the the DID followed by the service endpoint identifier, ex. did:web:whtwnd.com#whitewind_blog.
     /// More information can be found at https://atproto.com/specs/xrpc#service-proxying.
     /// </summary>

--- a/src/FishyFlip/ATProtocolBuilder.cs
+++ b/src/FishyFlip/ATProtocolBuilder.cs
@@ -162,6 +162,24 @@ public class ATProtocolBuilder
     }
 
     /// <summary>
+    /// Adds a cache set of ATProxy values with their respective service labels.
+    /// The key should resolve to the NSID of the service, ex. com.whtwnd.blog.
+    /// The value should be the the DID followed by the service endpoint identifier, ex. did:web:whtwnd.com#whitewind_blog.
+    /// More information can be found at https://atproto.com/specs/xrpc#service-proxying.
+    /// </summary>
+    /// <param name="proxyCache">Proxy value.</param>
+    /// <returns><see cref="ATProtocolBuilder"/>.</returns>
+    public ATProtocolBuilder WithATProxyCache(Dictionary<string, string> proxyCache)
+    {
+        foreach (var item in proxyCache)
+        {
+            this.atProtocolOptions.ATProxyCache[item.Key] = item.Value;
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Adds a cache set of ATHandle values with their respective service endpoint URIs.
     /// Use this to cache the service endpoints for the ATHandle values to avoid having to look them up.
     /// </summary>

--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -81,6 +81,11 @@ public class ATProtocolOptions
     internal ConcurrentDictionary<string, string> DidCache { get; } = new();
 
     /// <summary>
+    /// Gets the ATProxy Cache.
+    /// </summary>
+    internal ConcurrentDictionary<string, string> ATProxyCache { get; } = new();
+
+    /// <summary>
     /// Gets the source generation context.
     /// </summary>
     internal SourceGenerationContext SourceGenerationContext { get; }

--- a/src/FishyFlip/Lexicon/App/Bsky/Actor/ActorEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Actor/ActorEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Actor
     public static class ActorEndpoints
     {
 
+       public const string GroupNamespace = "app.bsky.actor";
+
        public const string GetPreferences = "/xrpc/app.bsky.actor.getPreferences";
 
        public const string GetProfile = "/xrpc/app.bsky.actor.getProfile";

--- a/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Feed/FeedEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Feed
     public static class FeedEndpoints
     {
 
+       public const string GroupNamespace = "app.bsky.feed";
+
        public const string DescribeFeedGenerator = "/xrpc/app.bsky.feed.describeFeedGenerator";
 
        public const string GetActorFeeds = "/xrpc/app.bsky.feed.getActorFeeds";

--- a/src/FishyFlip/Lexicon/App/Bsky/Graph/GraphEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Graph/GraphEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Graph
     public static class GraphEndpoints
     {
 
+       public const string GroupNamespace = "app.bsky.graph";
+
        public const string GetActorStarterPacks = "/xrpc/app.bsky.graph.getActorStarterPacks";
 
        public const string GetBlocks = "/xrpc/app.bsky.graph.getBlocks";

--- a/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Labeler/LabelerEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Labeler
     public static class LabelerEndpoints
     {
 
+       public const string GroupNamespace = "app.bsky.labeler";
+
        public const string GetServices = "/xrpc/app.bsky.labeler.getServices";
 
 

--- a/src/FishyFlip/Lexicon/App/Bsky/Notification/NotificationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Notification/NotificationEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Notification
     public static class NotificationEndpoints
     {
 
+       public const string GroupNamespace = "app.bsky.notification";
+
        public const string GetUnreadCount = "/xrpc/app.bsky.notification.getUnreadCount";
 
        public const string ListNotifications = "/xrpc/app.bsky.notification.listNotifications";

--- a/src/FishyFlip/Lexicon/App/Bsky/Unspecced/UnspeccedEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Unspecced/UnspeccedEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Unspecced
     public static class UnspeccedEndpoints
     {
 
+       public const string GroupNamespace = "app.bsky.unspecced";
+
        public const string GetConfig = "/xrpc/app.bsky.unspecced.getConfig";
 
        public const string GetPopularFeedGenerators = "/xrpc/app.bsky.unspecced.getPopularFeedGenerators";

--- a/src/FishyFlip/Lexicon/App/Bsky/Video/VideoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/App/Bsky/Video/VideoEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.App.Bsky.Video
     public static class VideoEndpoints
     {
 
+       public const string GroupNamespace = "app.bsky.video";
+
        public const string GetJobStatus = "/xrpc/app.bsky.video.getJobStatus";
 
        public const string GetUploadLimits = "/xrpc/app.bsky.video.getUploadLimits";

--- a/src/FishyFlip/Lexicon/Blue/Maril/Stellar/StellarEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Maril/Stellar/StellarEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
     public static class StellarEndpoints
     {
 
+       public const string GroupNamespace = "blue.maril.stellar";
+
        public const string GetActorReactions = "/xrpc/blue.maril.stellar.getActorReactions";
 
        public const string GetEmojis = "/xrpc/blue.maril.stellar.getEmojis";
@@ -48,6 +50,10 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Maril.Stellar.GetActorReactionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMarilStellarGetActorReactionsOutput!, cancellationToken, headers);
@@ -84,6 +90,10 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Maril.Stellar.GetEmojisOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMarilStellarGetEmojisOutput!, cancellationToken, headers);
@@ -123,6 +133,10 @@ namespace FishyFlip.Lexicon.Blue.Maril.Stellar
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Maril.Stellar.GetReactionsOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMarilStellarGetReactionsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Blue/Moji/Collection/CollectionEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Collection/CollectionEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
     public static class CollectionEndpoints
     {
 
+       public const string GroupNamespace = "blue.moji.collection";
+
        public const string GetItem = "/xrpc/blue.moji.collection.getItem";
 
        public const string ListCollection = "/xrpc/blue.moji.collection.listCollection";
@@ -41,6 +43,10 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
             queryStrings.Add("name=" + name);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Moji.Collection.GetItemOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMojiCollectionGetItemOutput!, cancellationToken, headers);
@@ -77,6 +83,10 @@ namespace FishyFlip.Lexicon.Blue.Moji.Collection
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Moji.Collection.ListCollectionOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMojiCollectionListCollectionOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Blue/Moji/Packs/PacksEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Blue/Moji/Packs/PacksEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
     public static class PacksEndpoints
     {
 
+       public const string GroupNamespace = "blue.moji.packs";
+
        public const string GetActorPacks = "/xrpc/blue.moji.packs.getActorPacks";
 
        public const string GetPack = "/xrpc/blue.moji.packs.getPack";
@@ -48,6 +50,10 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Moji.Packs.GetActorPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMojiPacksGetActorPacksOutput!, cancellationToken, headers);
@@ -81,6 +87,10 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Moji.Packs.GetPackOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMojiPacksGetPackOutput!, cancellationToken, headers);
@@ -102,6 +112,10 @@ namespace FishyFlip.Lexicon.Blue.Moji.Packs
             queryStrings.Add(string.Join("&", uris.Select(n => "uris=" + n)));
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Blue.Moji.Packs.GetPacksOutput>(endpointUrl, atp.Options.SourceGenerationContext.BlueMojiPacksGetPacksOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Buzz/Bookhive/BookhiveEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Buzz/Bookhive/BookhiveEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
     public static class BookhiveEndpoints
     {
 
+       public const string GroupNamespace = "buzz.bookhive";
+
        public const string GetBook = "/xrpc/buzz.bookhive.getBook";
 
        public const string GetProfile = "/xrpc/buzz.bookhive.getProfile";
@@ -36,6 +38,10 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
             queryStrings.Add("id=" + id);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Buzz.Bookhive.GetBookOutput>(endpointUrl, atp.Options.SourceGenerationContext.BuzzBookhiveGetBookOutput!, cancellationToken, headers);
@@ -66,6 +72,10 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Buzz.Bookhive.GetProfileOutput>(endpointUrl, atp.Options.SourceGenerationContext.BuzzBookhiveGetProfileOutput!, cancellationToken, headers);
@@ -105,6 +115,10 @@ namespace FishyFlip.Lexicon.Buzz.Bookhive
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Buzz.Bookhive.SearchBooksOutput>(endpointUrl, atp.Options.SourceGenerationContext.BuzzBookhiveSearchBooksOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ActorEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Actor/ActorEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Actor
     public static class ActorEndpoints
     {
 
+       public const string GroupNamespace = "chat.bsky.actor";
+
        public const string DeleteAccount = "/xrpc/chat.bsky.actor.deleteAccount";
 
        public const string ExportAccountData = "/xrpc/chat.bsky.actor.exportAccountData";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Convo/ConvoEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Convo
     public static class ConvoEndpoints
     {
 
+       public const string GroupNamespace = "chat.bsky.convo";
+
        public const string AcceptConvo = "/xrpc/chat.bsky.convo.acceptConvo";
 
        public const string AddReaction = "/xrpc/chat.bsky.convo.addReaction";

--- a/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Chat/Bsky/Moderation/ModerationEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Chat.Bsky.Moderation
     public static class ModerationEndpoints
     {
 
+       public const string GroupNamespace = "chat.bsky.moderation";
+
        public const string GetActorMetadata = "/xrpc/chat.bsky.moderation.getActorMetadata";
 
        public const string GetMessageContext = "/xrpc/chat.bsky.moderation.getMessageContext";

--- a/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Admin/AdminEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
     public static class AdminEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.admin";
+
        public const string DeleteAccount = "/xrpc/com.atproto.admin.deleteAccount";
 
        public const string DisableAccountInvites = "/xrpc/com.atproto.admin.disableAccountInvites";
@@ -134,6 +136,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             queryStrings.Add("did=" + did);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.AccountView>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminAccountView!, cancellationToken, headers);
@@ -155,6 +161,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             queryStrings.Add(string.Join("&", dids.Select(n => "dids=" + n)));
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetAccountInfosOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetAccountInfosOutput!, cancellationToken, headers);
@@ -191,6 +201,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetInviteCodesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetInviteCodesOutput!, cancellationToken, headers);
@@ -227,6 +241,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.GetSubjectStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminGetSubjectStatusOutput!, cancellationToken, headers);
@@ -263,6 +281,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Admin
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Admin.SearchAccountsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoAdminSearchAccountsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Com/Atproto/Identity/IdentityEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Identity/IdentityEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
     public static class IdentityEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.identity";
+
        public const string GetRecommendedDidCredentials = "/xrpc/com.atproto.identity.getRecommendedDidCredentials";
 
        public const string RefreshIdentity = "/xrpc/com.atproto.identity.refreshIdentity";
@@ -43,6 +45,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
         {
             var endpointUrl = GetRecommendedDidCredentials.ToString();
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Identity.GetRecommendedDidCredentialsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityGetRecommendedDidCredentialsOutput!, cancellationToken, headers);
         }
@@ -101,6 +107,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
             queryStrings.Add("did=" + did);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveDidOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityResolveDidOutput!, cancellationToken, headers);
@@ -124,6 +134,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
             queryStrings.Add("handle=" + handle);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Identity.ResolveHandleOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityResolveHandleOutput!, cancellationToken, headers);
@@ -149,6 +163,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Identity
             queryStrings.Add("identifier=" + identifier);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Identity.IdentityInfo>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoIdentityIdentityInfo!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Com/Atproto/Label/LabelEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Label/LabelEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
     public static class LabelEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.label";
+
        public const string QueryLabels = "/xrpc/com.atproto.label.queryLabels";
 
 
@@ -50,6 +52,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Label
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Label.QueryLabelsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoLabelQueryLabelsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Moderation/ModerationEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Moderation
     public static class ModerationEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.moderation";
+
        public const string CreateReport = "/xrpc/com.atproto.moderation.createReport";
 
 

--- a/src/FishyFlip/Lexicon/Com/Atproto/Repo/RepoEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Repo/RepoEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
     public static class RepoEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.repo";
+
        public const string ApplyWrites = "/xrpc/com.atproto.repo.applyWrites";
 
        public const string CreateRecord = "/xrpc/com.atproto.repo.createRecord";
@@ -131,6 +133,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             queryStrings.Add("repo=" + repo);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.DescribeRepoOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoDescribeRepoOutput!, cancellationToken, headers);
@@ -166,6 +172,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.GetRecordOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoGetRecordOutput!, cancellationToken, headers);
@@ -211,6 +221,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.ListMissingBlobsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoListMissingBlobsOutput!, cancellationToken, headers);
@@ -253,6 +267,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Repo
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Repo.ListRecordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoRepoListRecordsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Com/Atproto/Server/ServerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Server/ServerEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
     public static class ServerEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.server";
+
        public const string ActivateAccount = "/xrpc/com.atproto.server.activateAccount";
 
        public const string CheckAccountStatus = "/xrpc/com.atproto.server.checkAccountStatus";
@@ -89,6 +91,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         {
             var endpointUrl = CheckAccountStatus.ToString();
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.CheckAccountStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerCheckAccountStatusOutput!, cancellationToken, headers);
         }
@@ -311,6 +317,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         {
             var endpointUrl = DescribeServer.ToString();
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.DescribeServerOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerDescribeServerOutput!, cancellationToken, headers);
         }
@@ -342,6 +352,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetAccountInviteCodesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetAccountInviteCodesOutput!, cancellationToken, headers);
@@ -377,6 +391,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetServiceAuthOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetServiceAuthOutput!, cancellationToken, headers);
@@ -393,6 +411,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         {
             var endpointUrl = GetSession.ToString();
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.GetSessionOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerGetSessionOutput!, cancellationToken, headers);
         }
@@ -410,6 +432,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Server
         {
             var endpointUrl = ListAppPasswords.ToString();
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Server.ListAppPasswordsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoServerListAppPasswordsOutput!, cancellationToken, headers);
         }

--- a/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Sync/SyncEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
     public static class SyncEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.sync";
+
        public const string GetBlob = "/xrpc/com.atproto.sync.getBlob";
 
        public const string GetBlocks = "/xrpc/com.atproto.sync.getBlocks";
@@ -63,6 +65,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("cid=" + cid);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.GetBlob(endpointUrl, cancellationToken);
@@ -99,6 +105,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.GetCarAsync(endpointUrl, cancellationToken, onDecoded);
@@ -122,6 +132,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("hostname=" + hostname);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.GetHostStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncGetHostStatusOutput!, cancellationToken, headers);
@@ -148,6 +162,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("did=" + did);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.GetLatestCommitOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncGetLatestCommitOutput!, cancellationToken, headers);
@@ -187,6 +205,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.GetCarAsync(endpointUrl, cancellationToken, onDecoded);
@@ -225,6 +247,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.GetCarAsync(endpointUrl, cancellationToken, onDecoded);
@@ -248,6 +274,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             queryStrings.Add("did=" + did);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.GetRepoStatusOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncGetRepoStatusOutput!, cancellationToken, headers);
@@ -292,6 +322,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListBlobsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListBlobsOutput!, cancellationToken, headers);
@@ -322,6 +356,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListHostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListHostsOutput!, cancellationToken, headers);
@@ -352,6 +390,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListReposOutput!, cancellationToken, headers);
@@ -385,6 +427,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Sync
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Sync.ListReposByCollectionOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoSyncListReposByCollectionOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Com/Atproto/Temp/TempEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Atproto/Temp/TempEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
     public static class TempEndpoints
     {
 
+       public const string GroupNamespace = "com.atproto.temp";
+
        public const string AddReservedHandle = "/xrpc/com.atproto.temp.addReservedHandle";
 
        public const string CheckSignupQueue = "/xrpc/com.atproto.temp.checkSignupQueue";
@@ -48,6 +50,10 @@ namespace FishyFlip.Lexicon.Com.Atproto.Temp
         {
             var endpointUrl = CheckSignupQueue.ToString();
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Com.Atproto.Temp.CheckSignupQueueOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComAtprotoTempCheckSignupQueueOutput!, cancellationToken, headers);
         }

--- a/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/PinkseaEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Shinolabs/Pinksea/PinkseaEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
     public static class PinkseaEndpoints
     {
 
+       public const string GroupNamespace = "com.shinolabs.pinksea";
+
        public const string GetAuthorFeed = "/xrpc/com.shinolabs.pinksea.getAuthorFeed";
 
        public const string GetAuthorReplies = "/xrpc/com.shinolabs.pinksea.getAuthorReplies";
@@ -58,6 +60,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetAuthorFeedOutput!, cancellationToken, headers);
@@ -91,6 +97,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetAuthorRepliesOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetAuthorRepliesOutput!, cancellationToken, headers);
@@ -112,6 +122,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
             queryStrings.Add("did=" + did);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetHandleFromDidOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetHandleFromDidOutput!, cancellationToken, headers);
@@ -128,6 +142,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
         {
             var endpointUrl = GetIdentity.ToString();
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetIdentityOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetIdentityOutput!, cancellationToken, headers);
         }
@@ -151,6 +169,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
             queryStrings.Add("rkey=" + rkey);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetOekakiOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetOekakiOutput!, cancellationToken, headers);
@@ -175,6 +197,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
             queryStrings.Add("rkey=" + rkey);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetParentForReplyOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetParentForReplyOutput!, cancellationToken, headers);
@@ -205,6 +231,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetRecentOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetRecentOutput!, cancellationToken, headers);
@@ -238,6 +268,10 @@ namespace FishyFlip.Lexicon.Com.Shinolabs.Pinksea
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Shinolabs.Pinksea.GetTagFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComShinolabsPinkseaGetTagFeedOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Com/Whtwnd/Blog/BlogEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
     public static class BlogEndpoints
     {
 
+       public const string GroupNamespace = "com.whtwnd.blog";
+
        public const string GetAuthorPosts = "/xrpc/com.whtwnd.blog.getAuthorPosts";
 
        public const string GetEntryMetadataByName = "/xrpc/com.whtwnd.blog.getEntryMetadataByName";
@@ -38,6 +40,10 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
             queryStrings.Add("author=" + author);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetAuthorPostsOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetAuthorPostsOutput!, cancellationToken, headers);
@@ -64,6 +70,10 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
             queryStrings.Add("entryTitle=" + entryTitle);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetEntryMetadataByNameOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetEntryMetadataByNameOutput!, cancellationToken, headers);
@@ -85,6 +95,10 @@ namespace FishyFlip.Lexicon.Com.Whtwnd.Blog
             queryStrings.Add("postUri=" + postUri);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Com.Whtwnd.Blog.GetMentionsByEntryOutput>(endpointUrl, atp.Options.SourceGenerationContext.ComWhtwndBlogGetMentionsByEntryOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Community/Lexicon/Bookmarks/BookmarksEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Community/Lexicon/Bookmarks/BookmarksEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Bookmarks
     public static class BookmarksEndpoints
     {
 
+       public const string GroupNamespace = "community.lexicon.bookmarks";
+
        public const string GetActorBookmarks = "/xrpc/community.lexicon.bookmarks.getActorBookmarks";
 
 
@@ -47,6 +49,10 @@ namespace FishyFlip.Lexicon.Community.Lexicon.Bookmarks
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Community.Lexicon.Bookmarks.GetActorBookmarksOutput>(endpointUrl, atp.Options.SourceGenerationContext.CommunityLexiconBookmarksGetActorBookmarksOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/ActorEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Actor/ActorEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
     public static class ActorEndpoints
     {
 
+       public const string GroupNamespace = "fm.teal.alpha.actor";
+
        public const string GetProfile = "/xrpc/fm.teal.alpha.actor.getProfile";
 
        public const string GetProfiles = "/xrpc/fm.teal.alpha.actor.getProfiles";
@@ -36,6 +38,10 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
             queryStrings.Add("actor=" + actor);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfileOutput>(endpointUrl, atp.Options.SourceGenerationContext.FmTealAlphaActorGetProfileOutput!, cancellationToken, headers);
@@ -57,6 +63,10 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
             queryStrings.Add(string.Join("&", actors.Select(n => "actors=" + n)));
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.GetProfilesOutput>(endpointUrl, atp.Options.SourceGenerationContext.FmTealAlphaActorGetProfilesOutput!, cancellationToken, headers);
@@ -90,6 +100,10 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Actor
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Fm.Teal.Alpha.Actor.SearchActorsOutput>(endpointUrl, atp.Options.SourceGenerationContext.FmTealAlphaActorSearchActorsOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Feed/FeedEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Fm/Teal/Alpha/Feed/FeedEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
     public static class FeedEndpoints
     {
 
+       public const string GroupNamespace = "fm.teal.alpha.feed";
+
        public const string GetActorFeed = "/xrpc/fm.teal.alpha.feed.getActorFeed";
 
        public const string GetPlay = "/xrpc/fm.teal.alpha.feed.getPlay";
@@ -46,6 +48,10 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
             }
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetActorFeedOutput>(endpointUrl, atp.Options.SourceGenerationContext.FmTealAlphaFeedGetActorFeedOutput!, cancellationToken, headers);
@@ -70,6 +76,10 @@ namespace FishyFlip.Lexicon.Fm.Teal.Alpha.Feed
             queryStrings.Add("rkey=" + rkey);
 
             var headers = new Dictionary<string, string>();
+            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))
+            {
+                headers.Add(Constants.AtProtoProxy, proxyUrl);
+            }
             headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);
             endpointUrl += string.Join("&", queryStrings);
             return atp.Get<FishyFlip.Lexicon.Fm.Teal.Alpha.Feed.GetPlayOutput>(endpointUrl, atp.Options.SourceGenerationContext.FmTealAlphaFeedGetPlayOutput!, cancellationToken, headers);

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Communication/CommunicationEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Communication
     public static class CommunicationEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.communication";
+
        public const string CreateTemplate = "/xrpc/tools.ozone.communication.createTemplate";
 
        public const string DeleteTemplate = "/xrpc/tools.ozone.communication.deleteTemplate";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Hosting/HostingEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Hosting/HostingEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Hosting
     public static class HostingEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.hosting";
+
        public const string GetAccountHistory = "/xrpc/tools.ozone.hosting.getAccountHistory";
 
 

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Moderation/ModerationEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Moderation
     public static class ModerationEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.moderation";
+
        public const string EmitEvent = "/xrpc/tools.ozone.moderation.emitEvent";
 
        public const string GetEvent = "/xrpc/tools.ozone.moderation.getEvent";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServerEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Server/ServerEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Server
     public static class ServerEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.server";
+
        public const string GetConfig = "/xrpc/tools.ozone.server.getConfig";
 
 

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Set/SetEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Set
     public static class SetEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.set";
+
        public const string AddValues = "/xrpc/tools.ozone.set.addValues";
 
        public const string DeleteSet = "/xrpc/tools.ozone.set.deleteSet";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Setting/SettingEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Setting
     public static class SettingEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.setting";
+
        public const string ListOptions = "/xrpc/tools.ozone.setting.listOptions";
 
        public const string RemoveOptions = "/xrpc/tools.ozone.setting.removeOptions";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SignatureEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Signature/SignatureEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Signature
     public static class SignatureEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.signature";
+
        public const string FindCorrelation = "/xrpc/tools.ozone.signature.findCorrelation";
 
        public const string FindRelatedAccounts = "/xrpc/tools.ozone.signature.findRelatedAccounts";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Team/TeamEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Team
     public static class TeamEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.team";
+
        public const string AddMember = "/xrpc/tools.ozone.team.addMember";
 
        public const string DeleteMember = "/xrpc/tools.ozone.team.deleteMember";

--- a/src/FishyFlip/Lexicon/Tools/Ozone/Verification/VerificationEndpoints.g.cs
+++ b/src/FishyFlip/Lexicon/Tools/Ozone/Verification/VerificationEndpoints.g.cs
@@ -14,6 +14,8 @@ namespace FishyFlip.Lexicon.Tools.Ozone.Verification
     public static class VerificationEndpoints
     {
 
+       public const string GroupNamespace = "tools.ozone.verification";
+
        public const string GrantVerifications = "/xrpc/tools.ozone.verification.grantVerifications";
 
        public const string ListVerifications = "/xrpc/tools.ozone.verification.listVerifications";

--- a/tools/FFSourceGen/Program.cs
+++ b/tools/FFSourceGen/Program.cs
@@ -1561,6 +1561,8 @@ public partial class AppCommands
         sb.AppendLine($"    public static class {className}");
         sb.AppendLine("    {");
         sb.AppendLine();
+        sb.AppendLine($"       public const string GroupNamespace = \"{group.Key.ToLower()}\";");
+        sb.AppendLine();
         foreach (var item in group)
         {
             sb.AppendLine($"       public const string {item.ClassName} = \"/xrpc/{item.Id}\";");
@@ -1745,7 +1747,14 @@ public partial class AppCommands
                     {
                         sb.AppendLine($"            headers.Add(Constants.AtProtoProxy, atp.Options.OzoneProxyHeader);");
                     }
-
+                    else if (!item.Id.Contains("app.bsky") || item.Id.Contains("com.atproto"))
+                    {
+                        sb.AppendLine($"            if (atp.TryFetchProxy(GroupNamespace, out var proxyUrl))");
+                        sb.AppendLine("            {");
+                        sb.AppendLine($"                headers.Add(Constants.AtProtoProxy, proxyUrl);");
+                        sb.AppendLine("            }");
+                    }
+                    
                     sb.AppendLine($"            headers.Add(Constants.AtProtoAcceptLabelers, atp.Options.LabelDefinitionsHeader);");
 
                     if (inputProperties.Count > 2)


### PR DESCRIPTION
This PR adds basic (And I do mean basic) `atproto-proxy` support for [service proxy](https://atproto.com/specs/xrpc#service-proxying). 

```csharp
var proxyCache = new Dictionary<string, string>
{
    { "com.whtwnd.blog", "did:web:whtwnd#whitewind_blog" },
};

var atProtocolBuilder = new ATProtocolBuilder()
    .WithATProxyCache(proxyCache)
    .WithLogger(debugLog.CreateLogger("FishyFlipDebug"));
var atProtocol = atProtocolBuilder.Build();

var (mentions, error) = await atProtocol.ComWhtwndBlog.GetMentionsByEntryAsync(ATUri.Parse("at://did:plc:44ybard66vv44zksje25o7dz/com.whtwnd.blog.entry/3l5ii332pf32u", null));
```

This allows for using the `atproto-proxy` to handoff requests to other providers. It was already in place for Ozone and BSky chat, but this opens it for more services. 

An important note is that this does require the service to have a `did` with a service parameter. For example, [whtwnd.com](https://whtwnd.com/.well-known/did.json) has this, allowing for the handoff to happen. If the service you want to use this with doesn't support that, this won't work.