### PR TITLE
Add support for PLC Mirrors

### DIFF
--- a/src/FishyFlip/ATProtocolBuilder.cs
+++ b/src/FishyFlip/ATProtocolBuilder.cs
@@ -92,6 +92,19 @@ public class ATProtocolBuilder
     }
 
     /// <summary>
+    /// Sets the URI to use for <see cref="PlcDirectory"/> lookups.
+    /// Defaults to https://plc.directory/.
+    /// For alternatives, check out https://github.com/bsky-watch/plc-mirror.
+    /// </summary>
+    /// <param name="mirror">Mirror Uri.</param>
+    /// <returns><see cref="ATProtocolBuilder"/>.</returns>
+    public ATProtocolBuilder WithPlcMirror(Uri mirror)
+    {
+        this.atProtocolOptions.PlcDirectoryUrl = mirror;
+        return this;
+    }
+
+    /// <summary>
     /// Sets UseServiceEndpointUponLogin.
     /// </summary>
     /// <param name="serviceEndpointUponLogin">Value for UseServiceEndpointUponLogin.</param>

--- a/src/FishyFlip/ATProtocolOptions.cs
+++ b/src/FishyFlip/ATProtocolOptions.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using FishyFlip.Tools.Json;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 using System.Collections.Concurrent;
 using System.Net;
 
@@ -50,6 +51,11 @@ public class ATProtocolOptions
     /// Defaults to https://public.api.bsky.app.
     /// </summary>
     public Uri Url { get; internal set; }
+
+    /// <summary>
+    /// Gets the Plc Directory Url.
+    /// </summary>
+    public Uri PlcDirectoryUrl { get; internal set; } = new Uri("https://plc.directory/");
 
     /// <summary>
     /// Gets the user agent. Defaults to FishyFlip.

--- a/src/FishyFlip/PlcDirectory.cs
+++ b/src/FishyFlip/PlcDirectory.cs
@@ -10,7 +10,6 @@ namespace FishyFlip;
 public sealed class PlcDirectory : IDisposable
 {
     private ATProtocol proto;
-    private HttpClient client;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlcDirectory"/> class.
@@ -18,7 +17,6 @@ public sealed class PlcDirectory : IDisposable
     /// <param name="proto"><see cref="ATProtocol"/>.</param>
     internal PlcDirectory(ATProtocol proto)
     {
-        this.client = new HttpClient() { BaseAddress = new Uri("https://plc.directory/") };
         this.proto = proto;
     }
 
@@ -33,8 +31,8 @@ public sealed class PlcDirectory : IDisposable
     public async Task<Result<DidDoc?>> GetDidDocAsync(ATDid identifier, CancellationToken cancellationToken = default)
     {
         // Url: https://plc.directory/{identifier}
-        string url = $"/{identifier}";
-        return await this.client.Get<DidDoc?>(url, this.Options.SourceGenerationContext.DidDoc!, this.Options.JsonSerializerOptions, cancellationToken, this.Options.Logger);
+        var url = new Uri(this.Options.PlcDirectoryUrl, $"/{identifier}");
+        return await this.proto.Client.Get<DidDoc?>(url.ToString(), this.Options.SourceGenerationContext.DidDoc!, this.Options.JsonSerializerOptions, cancellationToken, this.Options.Logger);
     }
 
     /// <summary>
@@ -42,6 +40,5 @@ public sealed class PlcDirectory : IDisposable
     /// </summary>
     public void Dispose()
     {
-        this.client.Dispose();
     }
 }


### PR DESCRIPTION
This PR adds support for PLC Mirror URIs for `PlcDirectory`. If you host your own mirror or want to use another (Like with [plc-mirror](https://github.com/bsky-watch/plc-mirror) you can update it with `public ATProtocolBuilder WithPlcMirror(Uri mirror)`
