### PR TITLE
Fix JetStream WebSocket receiving partial messages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="MSTest" Version="3.10.4" />
     <PackageVersion Include="GitVersion.MSBuild" Version="6.4.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="7.1.0" />
-    <PackageVersion Include="DnsClient" Version="1.4.0" />
+    <PackageVersion Include="DnsClient" Version="1.8.0" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />


### PR DESCRIPTION
WebSocket messages don't always come in one whole chunk, and previously the JetStream WebSocket handler would simply ignore non-end-of-message packets, this would result in it trying to parse invalid JSON when particularly big records were sent over the socket. This patch fixes the problem by concatenating messages before parsing them. 

There are definitely more efficient ways of doing this instead of using MemoryStream but this works and I've tested it in production [as part of my bot](https://bsky.app/profile/you-died.bsky.social) for a few weeks now.