### PR TITLE
Downgrade DNSClient

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="MSTest" Version="3.10.4" />
     <PackageVersion Include="GitVersion.MSBuild" Version="6.4.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="7.1.0" />
-    <PackageVersion Include="DnsClient" Version="1.8.0" />
+    <PackageVersion Include="DnsClient" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />


### PR DESCRIPTION
Fixes #319 (I think)

Based on the previous PR using 1.4.0 to not pull down the newer dependencies, and so this _actually_ works on netstandard2.0 targets, which is the intention, I am fine downgrading this for now, and in the future removing it outright and turning that into an interface for people to make their own implementations. FishyFlip shouldn't have dependencies it doesn't need.