### PR TITLE
Avoid byte[] GC allocation and copy when reading MemoryStream

### DIFF
--- a/src/FishyFlip/ATJetStream.cs
+++ b/src/FishyFlip/ATJetStream.cs
@@ -272,7 +272,7 @@ public sealed class ATJetStream : IDisposable
                     continue;
                 }
 
-                ReadOnlySpan<byte> messageBytes = receiveStream.ToArray();
+                ReadOnlySpan<byte> messageBytes = receiveStream.GetBuffer().AsSpan(0, (int)receiveStream.Length);
                 receiveStream.SetLength(0);
 
                 if (this.compression)


### PR DESCRIPTION
The recently merged https://github.com/drasticactions/FishyFlip/pull/318 inadvertently reintroduced some avoidable copies and allocations.