### PR TITLE
Precalculate result length in DecodeBase32

### DIFF
--- a/src/FishyFlip/Models/ATCid.cs
+++ b/src/FishyFlip/Models/ATCid.cs
@@ -360,7 +360,9 @@ public class ATCid : IEquatable<ATCid>
         // Remove padding
         input = input.TrimEnd('=');
 
-        var result = new List<byte>();
+        var resultFinalLength = input.Length * 5 / 8;
+        var result = new byte[resultFinalLength];
+        var resultLength = 0;
         var buffer = 0;
         var bufferLength = 0;
 
@@ -377,12 +379,12 @@ public class ATCid : IEquatable<ATCid>
 
             if (bufferLength >= 8)
             {
-                result.Add((byte)(buffer >> (bufferLength - 8)));
+                result[resultLength++] = (byte)(buffer >> (bufferLength - 8));
                 bufferLength -= 8;
             }
         }
 
-        return result.ToArray();
+        return result;
     }
 
     private static string EncodeBase32(byte[] input)


### PR DESCRIPTION
This avoids intermediate `List<byte>` and its growth buffers.
This accounted for 10% of the `byte[]` allocations (by size) and 33% (by number of allocations) of `byte[]`, which is the second most allocated type (after `System.String`)

I plan to remove even that remaining pre-sized `byte[]` allocation in a future PR.