### PR TITLE
Dispose JsonDocuments so that its internal buffers can be returned to the pool

### DIFF
--- a/src/FishyFlip/Tools/Json/ATCidJsonConverter.cs
+++ b/src/FishyFlip/Tools/Json/ATCidJsonConverter.cs
@@ -14,19 +14,22 @@ public class ATCidJsonConverter : JsonConverter<ATCid?>
     {
         if (JsonDocument.TryParseValue(ref reader, out var doc))
         {
-            if (doc.RootElement.ValueKind == JsonValueKind.Object)
+            using (doc)
             {
-                if (doc.RootElement.TryGetProperty("$link", out var type))
+                if (doc.RootElement.ValueKind == JsonValueKind.Object)
                 {
-                    var typeString = type.GetString()?.Trim() ?? string.Empty;
+                    if (doc.RootElement.TryGetProperty("$link", out var type))
+                    {
+                        var typeString = type.GetString()?.Trim() ?? string.Empty;
+                        return string.IsNullOrEmpty(typeString) ? null : ATCid.Decode(typeString);
+                    }
+                }
+
+                if (doc.RootElement.ValueKind is JsonValueKind.String)
+                {
+                    var typeString = doc.RootElement.GetString()?.Trim() ?? string.Empty;
                     return string.IsNullOrEmpty(typeString) ? null : ATCid.Decode(typeString);
                 }
-            }
-
-            if (doc.RootElement.ValueKind is JsonValueKind.String)
-            {
-                var typeString = doc.RootElement.GetString()?.Trim() ?? string.Empty;
-                return string.IsNullOrEmpty(typeString) ? null : ATCid.Decode(typeString);
             }
         }
 

--- a/src/FishyFlip/Tools/Json/ATObjectJsonReader.cs
+++ b/src/FishyFlip/Tools/Json/ATObjectJsonReader.cs
@@ -22,26 +22,29 @@ public static class ATObjectJsonReader
         {
             if (JsonDocument.TryParseValue(ref reader, out var doc))
             {
-                if (doc.RootElement.TryGetProperty("$type", out var type))
+                using (doc)
                 {
-                    var text = type.GetString()?.Trim() ?? string.Empty;
-                    var atObject = ATObject.ToATObject(doc.RootElement, text);
-                    if (atObject is not null)
+                    if (doc.RootElement.TryGetProperty("$type", out var type))
                     {
-                        return atObject;
-                    }
-
-                    var rawText = doc.RootElement.GetRawText();
-                    foreach (var converter in converters)
-                    {
-                        if (converter.SupportedTypes.Contains(text))
+                        var text = type.GetString()?.Trim() ?? string.Empty;
+                        var atObject = ATObject.ToATObject(doc.RootElement, text);
+                        if (atObject is not null)
                         {
-                            atObject = converter.Read(rawText, text, options);
-                            break;
+                            return atObject;
                         }
-                    }
 
-                    return atObject ?? new UnknownATObject() { Type = text, Json = rawText };
+                        var rawText = doc.RootElement.GetRawText();
+                        foreach (var converter in converters)
+                        {
+                            if (converter.SupportedTypes.Contains(text))
+                            {
+                                atObject = converter.Read(rawText, text, options);
+                                break;
+                            }
+                        }
+
+                        return atObject ?? new UnknownATObject() { Type = text, Json = rawText };
+                    }
                 }
             }
         }


### PR DESCRIPTION
`byte[]` went from being the 2nd most allocated type to the 9th (by size).

`SharedArrayPool<byte>.Rent` now performs negligible allocations (used to be by far the top allocator for `byte[]`).